### PR TITLE
Add Dependabot automerge workflow

### DIFF
--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -1,0 +1,14 @@
+name: Dependabot Automerge
+
+'on':
+  pull_request:
+    types: [opened, synchronize, reopened]
+  workflow_dispatch:
+
+jobs:
+  dependabot-automerge:
+    uses: leynos/shared-actions/.github/workflows/dependabot-automerge.yml@235d2d07b9a321364a742310873f6732d7228e72
+    permissions:
+      contents: write
+      pull-requests: write
+    secrets: inherit


### PR DESCRIPTION
## Summary
- Adds a Dependabot Automerge workflow to automatically merge Dependabot PRs
- Uses a reusable workflow from the leynos/shared-actions repository

## Changes
### Workflow
- **dependabot-automerge.yml**: New workflow file at `.github/workflows/dependabot-automerge.yml`
- Triggers:
  - pull_request: types: [opened, synchronize, reopened]
  - workflow_dispatch
- Runs a job that delegates to:
  - `leynos/shared-actions/.github/workflows/dependabot-automerge.yml@235d2d07b9a321364a742310873f6732d7228e72`
- Permissions:
  - contents: write
  - pull-requests: write
- Secrets: inherited from the repository

## Rationale
- Enables automatic merging of Dependabot PRs when safe, reducing manual maintenance and keeping dependencies up to date.

## Testing
- [ ] Open or update a Dependabot PR to trigger the workflow (opened, synchronize, or reopened events)
- [ ] Verify the workflow triggers and runs the reusable automerge workflow
- [ ] Ensure automerge occurs only when checks pass and there are no merge conflicts
- [ ] Confirm that secrets are inherited and permissions are correctly applied

## Notes
- This PR references a specific commit hash for the reusable workflow. If the upstream workflow is updated, consider pinning to a newer commit hash.

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/568c6401-426b-4b2f-8988-2a87b3eef154

## Summary by Sourcery

CI:
- Introduce a Dependabot automerge GitHub Actions workflow that triggers on Dependabot pull request events and manual dispatch, delegating to a shared workflow with appropriate permissions and inherited secrets.