### PR TITLE
Add protocol exec mode with tty=false enforcement

### DIFF
--- a/docs/execplans/2-5-1-exec-attachment-with-tty-false-enforced.md
+++ b/docs/execplans/2-5-1-exec-attachment-with-tty-false-enforced.md
@@ -1,0 +1,396 @@
+# Step 2.5.1: Exec attachment with `tty = false` enforced
+
+This ExecPlan (execution plan) is a living document. The sections
+`Constraints`, `Tolerances`, `Risks`, `Progress`, `Surprises & Discoveries`,
+`Decision Log`, and `Outcomes & Retrospective` must be kept up to date as work
+proceeds.
+
+Status: COMPLETE
+
+## Purpose / big picture
+
+Podbot's exec subsystem currently supports two execution modes: Attached
+(streams connected, optional TTY) and Detached (no streams at all). Step 2.5 of
+the roadmap requires protocol-safe execution where an exec session has streams
+connected for proxying protocol bytes between an IDE client and a containerised
+app server, but TTY is permanently disabled. TTY escape sequences and terminal
+framing would corrupt protocol byte streams, so the enforcement must be
+structural, not caller-discipline.
+
+After this change, a library consumer can write:
+
+```rust
+let request = ExecRequest::new("container", cmd, ExecMode::Protocol)?;
+assert!(!request.tty());  // always false, even after .with_tty(true)
+```
+
+The new `ExecMode::Protocol` variant connects streams (stdin, stdout, stderr
+forwarded) but permanently enforces `tty = false`. No SIGWINCH listener is
+registered. No `resize_exec` calls are made. Existing Attached and Detached
+behaviour is unchanged.
+
+Observable success: `make check-fmt`, `make lint`, and `make test` all pass.
+New unit tests prove TTY enforcement. New BDD scenarios validate protocol-mode
+execution end-to-end. The first checkbox under Step 2.5 in the roadmap is
+marked done.
+
+## Constraints
+
+- No single code file may exceed 400 lines.
+  `src/engine/connection/exec/tests.rs` is currently at 386 lines, so new
+  protocol-mode tests must go in a new submodule file.
+- Every Rust module must begin with a `//!` module-level doc comment.
+- en-GB-oxendict spelling ("-ize" / "-yse" / "-our") in all comments and
+  documentation.
+- No `unwrap()` or `expect()` in production code (clippy denies `unwrap_used`
+  and `expect_used`).
+- Use directory modules (`mod.rs`), not self-named files
+  (`clippy::self_named_module_files` is denied).
+- Use `rstest` for unit tests, `rstest-bdd` v0.5.0 for behavioural tests.
+- BDD step functions must use `StepResult<T> = Result<T, String>` (no
+  `expect`/`panic`).
+- Existing public API signatures for `ExecMode::Attached` and
+  `ExecMode::Detached` must continue to work identically.
+- No new external crate dependencies.
+- `make check-fmt`, `make lint`, and `make test` must pass before any commit.
+- Commit messages use imperative mood; atomic commits; one logical unit per
+  commit.
+
+## Tolerances (exception triggers)
+
+- Scope: if implementation requires changes to more than 20 files or 500 net
+  lines of code, stop and escalate.
+- Interface: adding `ExecMode::Protocol` is a public API addition, which is
+  acceptable. If any existing public API signature must change beyond adding a
+  new enum variant, stop and escalate.
+- Dependencies: if a new external dependency is required, stop and escalate.
+- Iterations: if tests still fail after three focused fix iterations on any
+  single gate, stop and escalate.
+- File budget: if any file exceeds 400 lines after edits, extract into a
+  submodule before proceeding.
+
+## Risks
+
+- Risk: Adding a third `ExecMode` variant breaks exhaustive `match` blocks
+  throughout the codebase and tests. Severity: medium. Likelihood: high.
+  Mitigation: the compiler flags every non-exhaustive match. The number of
+  match sites is bounded (approximately five in production code, eight in
+  tests). Each is straightforward to extend.
+
+- Risk: `tests.rs` is at 386/400 lines and cannot absorb new test cases
+  inline. Severity: low. Likelihood: certain. Mitigation: extract protocol-mode
+  tests into a new `src/engine/connection/exec/tests/protocol_helpers.rs`
+  submodule, following the existing pattern of `detached_helpers.rs`.
+
+- Risk: BDD step helpers contain match arms on `ExecMode::Attached` and
+  `ExecMode::Detached` that must be extended for Protocol. Severity: low.
+  Likelihood: high. Mitigation: Protocol mode's start-exec configuration is
+  identical to Attached except `tty = false`; the new match arm reuses the
+  attached stream setup.
+
+## Progress
+
+- [x] (2026-03-18) Stage A: Add `ExecMode::Protocol` variant and update
+      `ExecRequest` logic.
+- [x] (2026-03-18) Stage B: Update exec dispatch match arms in
+      `exec_async_with_terminal_size_provider`.
+- [x] (2026-03-18) Stage C: Update `src/api/exec.rs` doc comment.
+- [x] (2026-03-18) Stage D: Unit tests for protocol mode in new
+      `protocol_helpers.rs`.
+- [x] (2026-03-18) Stage E: BDD feature scenarios and step helpers for
+      protocol mode.
+- [x] (2026-03-18) Stage F: Documentation updates (design doc, users guide,
+      roadmap).
+- [x] (2026-03-18) Stage G: Verification gates passed (`make check-fmt`,
+      `make lint`, `make test`, `make markdownlint` all exit 0).
+
+## Surprises & discoveries
+
+- Observation: `clippy::panic_in_result_fn` fires on `#[rstest]` test
+  functions that return `TestResult` and contain `assert!` macros directly in
+  the function body. Evidence: lint error during `make lint` on
+  protocol_helpers.rs tests. Impact: assertions must be extracted into
+  non-Result-returning helper functions, matching the existing codebase pattern
+  in `detached_helpers.rs` and the top-level `tests.rs`.
+
+## Decision log
+
+- Decision: Use a new `ExecMode::Protocol` variant rather than relying on
+  caller discipline with `.with_tty(false)`. Rationale: `ExecRequest::new()`
+  currently defaults `tty` to `true` for `ExecMode::Attached`. A caller could
+  construct an attached request and forget to call `.with_tty(false)`,
+  resulting in TTY framing that corrupts protocol streams. A dedicated variant
+  makes it impossible to construct a protocol-mode request with `tty = true`,
+  because enforcement is in the constructor and builder, not in caller
+  discipline. Option B (caller discipline) was rejected because it offers no
+  compile-time safety.
+
+- Decision: `ExecMode::is_attached()` returns true for Protocol.
+  Rationale: Protocol mode needs stream attachment (stdin/stdout/stderr
+  forwarded). Only TTY allocation differs from interactive Attached mode. The
+  Bollard options builders already delegate to `is_attached()` for stream flags
+  and `tty()` for terminal allocation, so extending `is_attached()` to include
+  Protocol gives correct behaviour automatically.
+
+- Decision: No changes to `build_create_exec_options`,
+  `build_start_exec_options`, `attached.rs`, or `terminal.rs`. Rationale: These
+  functions already delegate to `request.mode().is_attached()` for stream
+  attachment and `request.tty()` for TTY/resize decisions. Since Protocol sets
+  `is_attached() == true` and `tty() == false`, existing logic produces correct
+  Bollard options and skips resize handling without modification.
+
+## Outcomes & retrospective
+
+Shipped:
+
+- New `ExecMode::Protocol` variant providing protocol-safe execution with
+  permanent `tty = false` enforcement.
+- Seven new unit tests in `protocol_helpers.rs` covering constructor
+  enforcement, tty override rejection, Bollard options correctness, end-to-end
+  success/failure paths.
+- Two new BDD scenarios validating protocol execution with exit codes 0 and 1.
+- Updated design doc, users guide, and roadmap.
+- All four gates pass: `make check-fmt`, `make lint`, `make test`,
+  `make markdownlint`.
+
+Risk outcomes:
+
+- Non-exhaustive match arms were resolved mechanically in five locations
+  (production code and test helpers). The compiler flagged every instance.
+- The 386-line `tests.rs` file limit was respected by placing all new tests
+  in `tests/protocol_helpers.rs` (one new `mod` declaration added).
+
+Follow-up beyond Step 2.5.1:
+
+- None required. The Protocol mode variant is ready for use by the hosting
+  subsystem (Step 2.5 remaining tasks).
+
+## Context and orientation
+
+The podbot project is a Rust application that manages sandboxed AI agent
+containers via Bollard (a Docker/Podman API client). The exec subsystem handles
+running commands inside containers.
+
+Key types and files:
+
+- `src/engine/connection/exec/mod.rs` (347 lines): defines `ExecMode` (enum
+  with `Attached` and `Detached`), `ExecRequest` (struct holding container_id,
+  command, env, mode, and tty), `ExecResult`, the `ContainerExecClient` trait
+  (abstracting Bollard calls), and the `EngineConnector::exec_async()` method
+  that orchestrates the create/start/inspect lifecycle. Also contains
+  `build_create_exec_options()` and `build_start_exec_options()` which map an
+  `ExecRequest` to Bollard API option structs.
+
+- `src/engine/connection/exec/attached.rs` (317 lines): contains
+  `run_attached_session_async()` which wires stdin/stdout/stderr between the
+  local process and the container exec session. Spawns a stdin forwarding task,
+  manages SIGWINCH resize handling, and runs an output loop forwarding
+  `LogOutput` chunks.
+
+- `src/engine/connection/exec/terminal.rs` (130 lines):
+  `TerminalSizeProvider` trait, `SystemTerminalSizeProvider`,
+  `resize_exec_to_current_terminal_async()`, and SIGWINCH listener setup. The
+  function `maybe_sigwinch_listener` already checks `request.tty()` and returns
+  `None` when false, so Protocol mode will naturally skip SIGWINCH registration.
+
+- `src/api/exec.rs` (71 lines): `ExecParams<C>` struct and `exec()`
+  function, the library-facing orchestration entry point.
+
+- `src/engine/connection/exec/tests.rs` (386 lines): unit tests with
+  `MockExecClient`. Near the 400-line file limit.
+
+- `src/engine/connection/exec/tests/detached_helpers.rs` (117 lines),
+  `lifecycle_helpers.rs` (39 lines), `validation_tests.rs` (60 lines): test
+  helper submodules.
+
+- `tests/features/interactive_exec.feature` (45 lines): BDD feature with
+  five existing scenarios.
+
+- `tests/bdd_interactive_exec.rs` (47 lines): BDD test harness.
+
+- `tests/bdd_interactive_exec_helpers/` (`mod.rs`, `state.rs`, `steps.rs`,
+  `assertions.rs`): BDD helper modules.
+
+How `ExecMode` flows through the system today:
+
+1. `ExecMode::Attached` or `ExecMode::Detached` is chosen by the caller.
+2. `ExecRequest::new()` sets `tty = mode.is_attached()` (true for Attached,
+   false for Detached).
+3. `ExecRequest::with_tty()` allows override but clamps to
+   `self.mode.is_attached() && tty`.
+4. `build_create_exec_options()` uses `request.mode().is_attached()` to set
+   `attach_stdin/stdout/stderr`, and `attached && request.tty()` for `tty`.
+5. `build_start_exec_options()` uses `request.mode().is_attached()` for
+   `detach`, and `request.mode().is_attached() && request.tty()` for `tty`.
+6. `exec_async_with_terminal_size_provider()` matches on
+   `(request.mode(), start_result)` with four arms.
+7. In the Attached path, `run_attached_session_async` checks `request.tty()`
+   to decide whether to register SIGWINCH and call resize.
+
+What Protocol mode needs to do differently from Attached: `is_attached()`
+returns true (streams connected). `tty` is always false (enforced in
+constructor, cannot be overridden). No SIGWINCH listener, no resize calls
+(already handled by `request.tty()` being false). The dispatch match treats
+Protocol the same as Attached for stream handling.
+
+## Plan of work
+
+### Stage A: Add `ExecMode::Protocol` variant and update `ExecRequest`
+
+In `src/engine/connection/exec/mod.rs`, add a `Protocol` variant to the
+`ExecMode` enum. Update `is_attached()` to return true for both `Attached` and
+`Protocol`. Add an `is_protocol()` query method. Change the tty default in
+`ExecRequest::new()` from `mode.is_attached()` to `mode == ExecMode::Attached`,
+so Protocol starts with `tty = false`. Change `with_tty()` from
+`self.mode.is_attached() && tty` to
+`matches!(self.mode, ExecMode::Attached) && tty`, so Protocol cannot have tty
+overridden to true.
+
+### Stage B: Update exec dispatch match
+
+In the same file, update the match in `exec_async_with_terminal_size_provider`
+to combine the Attached and Protocol arms using `|` patterns:
+
+```rust
+(ExecMode::Attached | ExecMode::Protocol,
+ StartExecResults::Attached { output, input }) => { ... }
+(ExecMode::Attached | ExecMode::Protocol,
+ StartExecResults::Detached) => { return Err(...) }
+```
+
+No changes needed to `build_create_exec_options`, `build_start_exec_options`,
+`attached.rs`, or `terminal.rs` since they delegate to `is_attached()` and
+`tty()`.
+
+### Stage C: Update `src/api/exec.rs`
+
+Update the doc comment on the `tty` field of `ExecParams` to note it is ignored
+for Protocol and Detached modes.
+
+### Stage D: Unit tests for protocol mode
+
+Create `src/engine/connection/exec/tests/protocol_helpers.rs` with helper
+functions and `#[rstest]` tests covering:
+
+1. Protocol mode enforces `tty=false` in constructor.
+2. Protocol mode rejects `tty` override via `.with_tty(true)`.
+3. Protocol exec succeeds end-to-end (mock create/start/inspect) with correct
+   exit code and `resize_exec` never called.
+4. Protocol mode rejects detached daemon response.
+
+Add `mod protocol_helpers;` to `tests.rs`.
+
+### Stage E: BDD scenarios for protocol mode
+
+Add two new scenarios to `tests/features/interactive_exec.feature`:
+
+1. Protocol execution succeeds with tty disabled (exit code 0).
+2. Protocol execution returns non-zero exit code.
+
+Add `#[scenario]` wiring in `tests/bdd_interactive_exec.rs`. Add
+`#[given("protocol execution mode is selected")]` step in
+`tests/bdd_interactive_exec_helpers/steps.rs`. Extend
+`configure_start_exec_expectation` and `configure_resize_expectation` match
+arms for `ExecMode::Protocol`.
+
+### Stage F: Documentation updates
+
+Update `docs/podbot-design.md` (Interactive exec semantics section) to describe
+Protocol mode. Update `docs/users-guide.md` (exec section) with a note about
+`ExecMode::Protocol`. Check the first task under Step 2.5 in
+`docs/podbot-roadmap.md`.
+
+### Stage G: Verification gates
+
+Run `make check-fmt`, `make lint`, `make test`, and
+`MDLINT=/root/.bun/bin/markdownlint-cli2 make markdownlint`. Fix and rerun if
+any fail.
+
+## Concrete steps
+
+All commands are run from `/home/user/project`.
+
+Stage A verification:
+
+```bash
+cargo check --all-targets --all-features 2>&1 | head -20
+```
+
+Expected: compiler errors from non-exhaustive matches in test code (resolved in
+Stage D/E).
+
+Stage D/E/F verification:
+
+```bash
+set -o pipefail
+cargo clean -p podbot
+make check-fmt 2>&1 | tee /tmp/check-fmt-podbot-2-5-1.out
+make lint 2>&1 | tee /tmp/lint-podbot-2-5-1.out
+make test 2>&1 | tee /tmp/test-podbot-2-5-1.out
+```
+
+Expected: all three exit 0.
+
+## Validation and acceptance
+
+Quality criteria:
+
+- `make check-fmt` exits 0.
+- `make lint` exits 0.
+- `make test` exits 0, including new unit tests in `protocol_helpers.rs` and
+  new BDD scenarios.
+- All existing tests pass unchanged.
+
+Quality method:
+
+- `ExecRequest::new("c", cmd, ExecMode::Protocol)` yields `tty() == false`.
+- `.with_tty(true)` on a Protocol request still yields `tty() == false`.
+- Protocol exec connects streams (`attach_*: true`) but sets `tty: false`.
+- `resize_exec` is never called during Protocol execution.
+- Existing Attached and Detached behaviour is unchanged.
+
+## Idempotence and recovery
+
+Each stage is additive and can be rerun safely. If a partial edit leaves the
+tree failing, revert only the incomplete hunks and replay from the last passing
+stage. After modifying `.feature` files, run `cargo clean -p podbot` to ensure
+rstest-bdd picks up the changes (feature files are read at compile time and
+incremental compilation does not track them).
+
+## Artifacts and notes
+
+(To be populated during implementation.)
+
+## Interfaces and dependencies
+
+The end state requires the following interface in
+`src/engine/connection/exec/mod.rs`:
+
+```rust
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ExecMode {
+    Attached,
+    Detached,
+    /// Attach streams for protocol proxying with tty permanently disabled.
+    Protocol,
+}
+
+impl ExecMode {
+    #[must_use]
+    const fn is_attached(self) -> bool {
+        matches!(self, Self::Attached | Self::Protocol)
+    }
+
+    #[must_use]
+    const fn is_protocol(self) -> bool {
+        matches!(self, Self::Protocol)
+    }
+}
+```
+
+The `ExecRequest::new()` constructor enforces
+`tty = (mode == ExecMode::Attached)`. The `with_tty()` builder enforces
+`tty = matches!(self.mode, ExecMode::Attached) && tty`.
+
+No new traits, no new crate dependencies. The `ContainerExecClient` trait is
+unchanged. Bollard options builders are unchanged.

--- a/docs/execplans/2-5-1-exec-attachment-with-tty-false-enforced.md
+++ b/docs/execplans/2-5-1-exec-attachment-with-tty-false-enforced.md
@@ -10,12 +10,13 @@ Status: COMPLETE
 ## Purpose / big picture
 
 Podbot's exec subsystem currently supports two execution modes: Attached
-(streams connected, optional TTY) and Detached (no streams at all). Step 2.5 of
-the roadmap requires protocol-safe execution where an exec session has streams
-connected for proxying protocol bytes between an IDE client and a containerised
-app server, but TTY is permanently disabled. TTY escape sequences and terminal
-framing would corrupt protocol byte streams, so the enforcement must be
-structural, not caller-discipline.
+(streams connected, optional pseudo-terminal (TTY)) and Detached (no streams at
+all). Step 2.5 of the roadmap requires protocol-safe execution where an exec
+session has streams connected for proxying protocol bytes between an integrated
+development environment (IDE) client and a containerised app server, but TTY is
+permanently disabled. TTY escape sequences and terminal framing would corrupt
+protocol byte streams, so the enforcement must be structural, not
+caller-discipline.
 
 After this change, a library consumer can write:
 
@@ -46,7 +47,8 @@ marked done.
   and `expect_used`).
 - Use directory modules (`mod.rs`), not self-named files
   (`clippy::self_named_module_files` is denied).
-- Use `rstest` for unit tests, `rstest-bdd` v0.5.0 for behavioural tests.
+- Use `rstest` for unit tests, `rstest-bdd` v0.5.0 for behaviour-driven
+  development (BDD) tests.
 - BDD step functions must use `StepResult<T> = Result<T, String>` (no
   `expect`/`panic`).
 - Existing public API signatures for `ExecMode::Attached` and

--- a/docs/execplans/2-5-1-exec-attachment-with-tty-false-enforced.md
+++ b/docs/execplans/2-5-1-exec-attachment-with-tty-false-enforced.md
@@ -13,7 +13,7 @@ Podbot's exec subsystem currently supports two execution modes: Attached
 (streams connected, optional pseudo-terminal (TTY)) and Detached (no streams at
 all). Step 2.5 of the roadmap requires protocol-safe execution where an exec
 session has streams connected for proxying protocol bytes between an integrated
-development environment (IDE) client and a containerised app server, but TTY is
+development environment (IDE) client and a containerized app server, but TTY is
 permanently disabled. TTY escape sequences and terminal framing would corrupt
 protocol byte streams, so the enforcement must be structural, not
 caller-discipline.
@@ -101,7 +101,7 @@ marked done.
       `protocol_helpers.rs`.
 - [x] (2026-03-18) Stage E: BDD feature scenarios and step helpers for
       protocol mode.
-- [x] (2026-03-18) Stage F: Documentation updates (design doc, users guide,
+- [x] (2026-03-18) Stage F: Documentation updates (design doc, user's guide,
       roadmap).
 - [x] (2026-03-18) Stage G: Verification gates passed (`make check-fmt`,
       `make lint`, `make test`, `make markdownlint` all exit 0).
@@ -151,7 +151,7 @@ Shipped:
   enforcement, tty override rejection, Bollard options correctness, end-to-end
   success/failure paths.
 - Two new BDD scenarios validating protocol execution with exit codes 0 and 1.
-- Updated design doc, users guide, and roadmap.
+- Updated design doc, user's guide, and roadmap.
 - All four gates pass: `make check-fmt`, `make lint`, `make test`,
   `make markdownlint`.
 
@@ -169,6 +169,10 @@ Follow-up beyond Step 2.5.1:
 
 ## Context and orientation
 
+The following walkthrough captures the pre-change code shape that this step
+built on. It is retained as historical context for the implementation plan
+below; the current shipped interface is described afterwards.
+
 The podbot project is a Rust application that manages sandboxed AI agent
 containers via Bollard (a Docker/Podman API client). The exec subsystem handles
 running commands inside containers.
@@ -176,12 +180,13 @@ running commands inside containers.
 Key types and files:
 
 - `src/engine/connection/exec/mod.rs` (347 lines): defines `ExecMode` (enum
-  with `Attached` and `Detached`), `ExecRequest` (struct holding container_id,
-  command, env, mode, and tty), `ExecResult`, the `ContainerExecClient` trait
-  (abstracting Bollard calls), and the `EngineConnector::exec_async()` method
-  that orchestrates the create/start/inspect lifecycle. Also contains
-  `build_create_exec_options()` and `build_start_exec_options()` which map an
-  `ExecRequest` to Bollard API option structs.
+  with `Attached` and `Detached` before this change), `ExecRequest` (struct
+  holding container_id, command, env, mode, and tty), `ExecResult`, the
+  `ContainerExecClient` trait (abstracting Bollard calls), and the
+  `EngineConnector::exec_async()` method that orchestrates the
+  create/start/inspect lifecycle. Also contains `build_create_exec_options()`
+  and `build_start_exec_options()` which map an `ExecRequest` to Bollard API
+  option structs.
 
 - `src/engine/connection/exec/attached.rs` (317 lines): contains
   `run_attached_session_async()` which wires stdin/stdout/stderr between the
@@ -213,7 +218,7 @@ Key types and files:
 - `tests/bdd_interactive_exec_helpers/` (`mod.rs`, `state.rs`, `steps.rs`,
   `assertions.rs`): BDD helper modules.
 
-How `ExecMode` flows through the system today:
+Pre-change `ExecMode` flow:
 
 1. `ExecMode::Attached` or `ExecMode::Detached` is chosen by the caller.
 2. `ExecRequest::new()` sets `tty = mode.is_attached()` (true for Attached,
@@ -229,22 +234,35 @@ How `ExecMode` flows through the system today:
 7. In the Attached path, `run_attached_session_async` checks `request.tty()`
    to decide whether to register SIGWINCH and call resize.
 
-What Protocol mode needs to do differently from Attached: `is_attached()`
-returns true (streams connected). `tty` is always false (enforced in
-constructor, cannot be overridden). No SIGWINCH listener, no resize calls
-(already handled by `request.tty()` being false). The dispatch match treats
-Protocol the same as Attached for stream handling.
+The shipped implementation differs from that pre-change walkthrough as follows:
+
+1. `ExecMode` now has `Attached`, `Detached`, and `Protocol` variants and is
+   marked `#[non_exhaustive]` to protect downstream callers from exhaustive
+   matches.
+2. `ExecMode::is_attached()` returns true for `Attached` and `Protocol`.
+3. `ExecMode::is_protocol()` is a public query method that returns true only
+   for `Protocol`.
+4. `ExecRequest::new()` defaults `tty` to true only for `ExecMode::Attached`,
+   so `ExecMode::Protocol` starts with `tty = false`.
+5. `ExecRequest::with_tty()` only honours `tty = true` for
+   `ExecMode::Attached`; `Detached` and `Protocol` stay at `tty = false`.
+6. `build_create_exec_options()` and `build_start_exec_options()` still rely
+   on `is_attached()` for stream wiring and `tty()` for terminal allocation, so
+   Protocol gets attached streams with TTY disabled.
+7. The dispatch match treats `Attached` and `Protocol` identically for stream
+   handling, while resize behaviour still keys off `request.tty()`.
 
 ## Plan of work
 
 ### Stage A: Add `ExecMode::Protocol` variant and update `ExecRequest`
 
 In `src/engine/connection/exec/mod.rs`, add a `Protocol` variant to the
-`ExecMode` enum. Update `is_attached()` to return true for both `Attached` and
-`Protocol`. Add an `is_protocol()` query method. Change the tty default in
-`ExecRequest::new()` from `mode.is_attached()` to `mode == ExecMode::Attached`,
-so Protocol starts with `tty = false`. Change `with_tty()` from
-`self.mode.is_attached() && tty` to
+`ExecMode` enum and mark the enum `#[non_exhaustive]` to avoid downstream
+breakage from future variants. Update `is_attached()` to return true for both
+`Attached` and `Protocol`. Add a public `is_protocol()` query method. Change
+the tty default in `ExecRequest::new()` from `mode.is_attached()` to
+`mode == ExecMode::Attached`, so Protocol starts with `tty = false`. Change
+`with_tty()` from `self.mode.is_attached() && tty` to
 `matches!(self.mode, ExecMode::Attached) && tty`, so Protocol cannot have tty
 overridden to true.
 
@@ -384,7 +402,7 @@ impl ExecMode {
     }
 
     #[must_use]
-    const fn is_protocol(self) -> bool {
+    pub const fn is_protocol(self) -> bool {
         matches!(self, Self::Protocol)
     }
 }

--- a/docs/podbot-design.md
+++ b/docs/podbot-design.md
@@ -756,20 +756,23 @@ service, to manage token refresh independently of active sessions.
 
 ### Interactive exec semantics
 
-`podbot exec` supports three execution modes:
+`podbot exec` exposes two CLI modes:
 
 - Attached mode (default) wires local stdin/stdout/stderr to the exec session.
 - Detached mode (`--detach`) starts the exec session without stream
   attachment and waits for completion.
-- Protocol mode (`ExecMode::Protocol`) connects streams like attached mode but
-  permanently disables TTY allocation. This mode is the foundation for
-  `podbot host`, which proxies protocol bytes between an IDE client and a
-  containerised app server. Because `tty` is always false, protocol mode never
-  registers a SIGWINCH listener and never calls `resize_exec`.
 
-Pseudo-terminal (TTY) allocation is enabled only for attached mode when both
-local stdin and stdout are terminals. Detached and protocol modes always use
-`tty = false`.
+The engine/library layer also has an internal protocol path
+(`ExecMode::Protocol`) used by `podbot host` to proxy bytes between an IDE
+client and a containerized app server. Protocol mode keeps stdin/stdout/stderr
+attached like interactive exec, but permanently disables TTY allocation so the
+byte stream is not corrupted by terminal framing. Because `tty` is always
+false, protocol mode never registers a `SIGWINCH` listener and never calls
+`resize_exec`.
+
+Pseudo-terminal (TTY) allocation is enabled only for attached CLI exec when
+both local stdin and stdout are terminals. Detached exec and protocol exec
+always use `tty = false`.
 
 When TTY is enabled, Podbot sends an initial resize to match the current
 terminal dimensions. On Unix targets, Podbot then subscribes to `SIGWINCH` and

--- a/docs/podbot-design.md
+++ b/docs/podbot-design.md
@@ -756,14 +756,20 @@ service, to manage token refresh independently of active sessions.
 
 ### Interactive exec semantics
 
-`podbot exec` supports two execution modes:
+`podbot exec` supports three execution modes:
 
 - Attached mode (default) wires local stdin/stdout/stderr to the exec session.
 - Detached mode (`--detach`) starts the exec session without stream
   attachment and waits for completion.
+- Protocol mode (`ExecMode::Protocol`) connects streams like attached mode but
+  permanently disables TTY allocation. This mode is the foundation for
+  `podbot host`, which proxies protocol bytes between an IDE client and a
+  containerised app server. Because `tty` is always false, protocol mode never
+  registers a SIGWINCH listener and never calls `resize_exec`.
 
 Pseudo-terminal (TTY) allocation is enabled only for attached mode when both
-local stdin and stdout are terminals. Detached mode always uses `tty = false`.
+local stdin and stdout are terminals. Detached and protocol modes always use
+`tty = false`.
 
 When TTY is enabled, Podbot sends an initial resize to match the current
 terminal dimensions. On Unix targets, Podbot then subscribes to `SIGWINCH` and

--- a/docs/podbot-roadmap.md
+++ b/docs/podbot-roadmap.md
@@ -163,7 +163,7 @@ Provide non-TTY execution for app-server hosting protocols.
 
 **Tasks:**
 
-- [ ] Implement exec attachment with `tty = false` enforced.
+- [x] Implement exec attachment with `tty = false` enforced.
 - [ ] Implement byte-stream proxy loops: stdin -> container stdin, container
   stdout -> host stdout, and container stderr -> host stderr.
 - [ ] Keep proxy buffering bounded, so hosted protocols can apply backpressure.

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -104,10 +104,10 @@ Execution behaviour:
   stdin and stdout are terminals.
 - When TTY is enabled, podbot sends an initial resize to the daemon. On Unix
   targets, podbot also listens for `SIGWINCH` and propagates window-size
-  changes. Detached mode, protocol mode, or attached mode with TTY disabled,
-  does not register a resize listener. podbot reads terminal size using
-  `stty size`; if that command is unavailable or returns unexpected output,
-  resize propagation is skipped and execution continues.
+  changes. Detached mode, protocol mode, or attached mode with TTY disabled do
+  not register a resize listener. podbot reads terminal size using `stty size`;
+  if that command is unavailable or returns unexpected output, resize
+  propagation is skipped and execution continues.
 - podbot polls exec status until the command exits, then uses the daemon exit
   code as the CLI outcome. Exit code `0` returns success. Non-zero values in
   the `1..=255` range are returned directly, negative values are mapped to `1`,

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -95,14 +95,19 @@ Execution behaviour:
 - Attached mode forwards stdin/stdout/stderr between the local terminal and the
   container exec session.
 - Detached mode does not attach streams and always uses `tty = false`.
+- Protocol mode (`ExecMode::Protocol`) connects streams like attached mode but
+  permanently disables TTY allocation. This mode is used internally by the
+  hosting subsystem to proxy protocol bytes without TTY framing corruption.
+  Library consumers can use it for non-TTY attached execution where stdout must
+  remain a pure byte stream.
 - TTY allocation is enabled only when attached mode is selected and both local
   stdin and stdout are terminals.
 - When TTY is enabled, podbot sends an initial resize to the daemon. On Unix
   targets, podbot also listens for `SIGWINCH` and propagates window-size
-  changes. Detached mode, or attached mode with TTY disabled, does not register
-  a resize listener. podbot reads terminal size using `stty size`; if that
-  command is unavailable or returns unexpected output, resize propagation is
-  skipped and execution continues.
+  changes. Detached mode, protocol mode, or attached mode with TTY disabled,
+  does not register a resize listener. podbot reads terminal size using
+  `stty size`; if that command is unavailable or returns unexpected output,
+  resize propagation is skipped and execution continues.
 - podbot polls exec status until the command exits, then uses the daemon exit
   code as the CLI outcome. Exit code `0` returns success. Non-zero values in
   the `1..=255` range are returned directly, negative values are mapped to `1`,

--- a/src/api/exec.rs
+++ b/src/api/exec.rs
@@ -28,11 +28,18 @@ pub struct ExecParams<'a, C: ContainerExecClient> {
     pub container: &'a str,
     /// Command argv to execute.
     pub command: Vec<String>,
-    /// Attached, detached, or protocol execution mode.
+    /// Execution mode:
+    /// - `Attached`: run with an interactive, user-facing stdio stream.
+    /// - `Detached`: start without attaching to stdio.
+    /// - `Protocol`: run in protocol-safe stream-proxy mode for forwarding raw
+    ///   stdio over a higher-level protocol. This mode is intended for API
+    ///   clients rather than direct terminal use and always disables TTY.
     pub mode: ExecMode,
-    /// Whether to allocate a pseudo-terminal (only effective in attached
-    /// mode; ignored for protocol and detached modes). The caller is
-    /// responsible for determining whether the local terminal supports TTY.
+    /// Whether to allocate a pseudo-terminal.
+    ///
+    /// This flag is only effective in `Attached` mode. `Protocol` and
+    /// `Detached` mode always disable TTY regardless of this value. The caller
+    /// is responsible for determining whether the local terminal supports TTY.
     pub tty: bool,
     /// Tokio runtime handle for blocking execution.
     pub runtime_handle: &'a tokio::runtime::Handle,

--- a/src/api/exec.rs
+++ b/src/api/exec.rs
@@ -28,11 +28,11 @@ pub struct ExecParams<'a, C: ContainerExecClient> {
     pub container: &'a str,
     /// Command argv to execute.
     pub command: Vec<String>,
-    /// Attached or detached execution mode.
+    /// Attached, detached, or protocol execution mode.
     pub mode: ExecMode,
     /// Whether to allocate a pseudo-terminal (only effective in attached
-    /// mode). The caller is responsible for determining whether the local
-    /// terminal supports TTY.
+    /// mode; ignored for protocol and detached modes). The caller is
+    /// responsible for determining whether the local terminal supports TTY.
     pub tty: bool,
     /// Tokio runtime handle for blocking execution.
     pub runtime_handle: &'a tokio::runtime::Handle,

--- a/src/engine/connection/exec/mod.rs
+++ b/src/engine/connection/exec/mod.rs
@@ -92,12 +92,21 @@ pub enum ExecMode {
     Attached,
     /// Start without stream attachment and wait for exit.
     Detached,
+    /// Attach streams for protocol proxying with tty permanently disabled.
+    Protocol,
 }
 
 impl ExecMode {
     #[must_use]
     const fn is_attached(self) -> bool {
-        matches!(self, Self::Attached)
+        matches!(self, Self::Attached | Self::Protocol)
+    }
+
+    /// Return true when this mode is protocol-safe (streams attached, tty
+    /// permanently disabled).
+    #[must_use]
+    pub const fn is_protocol(self) -> bool {
+        matches!(self, Self::Protocol)
     }
 }
 
@@ -132,7 +141,7 @@ impl ExecRequest {
             command: validated_command,
             env: None,
             mode,
-            tty: mode.is_attached(),
+            tty: mode == ExecMode::Attached,
         })
     }
 
@@ -145,10 +154,10 @@ impl ExecRequest {
 
     /// Control pseudo-terminal allocation for attached mode.
     ///
-    /// Detached mode always forces `tty = false`.
+    /// Detached and protocol modes always force `tty = false`.
     #[must_use]
     pub const fn with_tty(mut self, tty: bool) -> Self {
-        self.tty = self.mode.is_attached() && tty;
+        self.tty = matches!(self.mode, ExecMode::Attached) && tty;
         self
     }
 
@@ -262,11 +271,17 @@ impl EngineConnector {
             })?;
 
         match (request.mode(), start_result) {
-            (ExecMode::Attached, bollard::exec::StartExecResults::Attached { output, input }) => {
+            (
+                ExecMode::Attached | ExecMode::Protocol,
+                bollard::exec::StartExecResults::Attached { output, input },
+            ) => {
                 run_attached_session_async(client, request, &exec_id, output, input, size_provider)
                     .await?;
             }
-            (ExecMode::Attached, bollard::exec::StartExecResults::Detached) => {
+            (
+                ExecMode::Attached | ExecMode::Protocol,
+                bollard::exec::StartExecResults::Detached,
+            ) => {
                 return Err(exec_failed(
                     request.container_id(),
                     "daemon returned detached start result for attached mode",

--- a/src/engine/connection/exec/mod.rs
+++ b/src/engine/connection/exec/mod.rs
@@ -284,7 +284,10 @@ impl EngineConnector {
             ) => {
                 return Err(exec_failed(
                     request.container_id(),
-                    "daemon returned detached start result for attached mode",
+                    format!(
+                        "daemon returned detached start result for {:?} mode",
+                        request.mode()
+                    ),
                 ));
             }
             (ExecMode::Detached, bollard::exec::StartExecResults::Attached { .. }) => {

--- a/src/engine/connection/exec/mod.rs
+++ b/src/engine/connection/exec/mod.rs
@@ -87,6 +87,7 @@ impl ContainerExecClient for Docker {
 
 /// Execution mode for container commands.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum ExecMode {
     /// Attach local terminal streams to the exec process.
     Attached,
@@ -284,10 +285,7 @@ impl EngineConnector {
             ) => {
                 return Err(exec_failed(
                     request.container_id(),
-                    format!(
-                        "daemon returned detached start result for {:?} mode",
-                        request.mode()
-                    ),
+                    "daemon returned detached start result for requested exec mode",
                 ));
             }
             (ExecMode::Detached, bollard::exec::StartExecResults::Attached { .. }) => {

--- a/src/engine/connection/exec/tests.rs
+++ b/src/engine/connection/exec/tests.rs
@@ -11,6 +11,7 @@ use super::*;
 use crate::error::{ContainerError, PodbotError};
 mod detached_helpers;
 mod lifecycle_helpers;
+mod protocol_helpers;
 mod validation_tests;
 
 mock! {

--- a/src/engine/connection/exec/tests/protocol_helpers.rs
+++ b/src/engine/connection/exec/tests/protocol_helpers.rs
@@ -1,0 +1,182 @@
+//! Protocol-mode exec tests verifying tty enforcement and stream behaviour.
+
+use bollard::container::LogOutput;
+use bollard::errors::Error as BollardError;
+use futures_util::stream;
+use rstest::rstest;
+
+use super::*;
+
+fn make_protocol_exec_request(
+    container_id: &str,
+    command: Vec<String>,
+) -> Result<ExecRequest, PodbotError> {
+    ExecRequest::new(container_id, command, ExecMode::Protocol)
+}
+
+fn default_protocol_command() -> Vec<String> {
+    vec![
+        String::from("codex"),
+        String::from("app-server"),
+        String::from("--listen"),
+        String::from("stdio"),
+    ]
+}
+
+fn setup_start_exec_protocol(client: &mut MockExecClient, output_messages: Vec<&'static [u8]>) {
+    client
+        .expect_start_exec()
+        .times(1)
+        .returning(move |_, options| {
+            assert_eq!(
+                options,
+                Some(StartExecOptions {
+                    detach: false,
+                    tty: false,
+                    output_capacity: None
+                })
+            );
+            let output_chunks = output_messages
+                .iter()
+                .map(|message| {
+                    Ok(LogOutput::StdOut {
+                        message: Vec::from(*message).into(),
+                    })
+                })
+                .collect::<Vec<Result<LogOutput, BollardError>>>();
+            let output_stream = stream::iter(output_chunks);
+            Box::pin(async move {
+                Ok(bollard::exec::StartExecResults::Attached {
+                    output: Box::pin(output_stream),
+                    input: Box::pin(tokio::io::sink()),
+                })
+            })
+        });
+}
+
+fn assert_protocol_request_properties(request: &ExecRequest) {
+    assert!(!request.tty(), "protocol mode must enforce tty = false");
+    assert!(
+        request.mode().is_attached(),
+        "protocol mode should be treated as attached"
+    );
+    assert!(
+        request.mode().is_protocol(),
+        "protocol mode should identify as protocol"
+    );
+}
+
+fn assert_protocol_create_options(options: &CreateExecOptions<String>) {
+    assert_eq!(options.attach_stdin, Some(true), "stdin must be attached");
+    assert_eq!(options.attach_stdout, Some(true), "stdout must be attached");
+    assert_eq!(options.attach_stderr, Some(true), "stderr must be attached");
+    assert_eq!(options.tty, Some(false), "tty must be false");
+}
+
+fn assert_protocol_start_options(options: &StartExecOptions) {
+    assert!(!options.detach, "detach must be false for protocol mode");
+    assert!(!options.tty, "tty must be false for protocol mode");
+}
+
+fn assert_exit_code(result: Result<ExecResult, PodbotError>, expected: i64, context: &str) {
+    let exec_result = result.expect(context);
+    assert_eq!(exec_result.exit_code(), expected, "exit code should match");
+}
+
+#[rstest]
+fn protocol_mode_enforces_tty_false_in_constructor() -> TestResult {
+    let request = make_protocol_exec_request("sandbox", default_protocol_command())?;
+    assert_protocol_request_properties(&request);
+    Ok(())
+}
+
+fn assert_tty_override_rejected(request: &ExecRequest) {
+    assert!(
+        !request.tty(),
+        "with_tty(true) must be rejected for protocol"
+    );
+}
+
+#[rstest]
+fn protocol_mode_rejects_tty_override() -> TestResult {
+    let request = make_protocol_exec_request("sandbox", default_protocol_command())?.with_tty(true);
+    assert_tty_override_rejected(&request);
+    Ok(())
+}
+
+#[rstest]
+fn protocol_mode_create_options_have_correct_flags() -> TestResult {
+    let request = make_protocol_exec_request("sandbox", default_protocol_command())?;
+    let options = build_create_exec_options(&request);
+    assert_protocol_create_options(&options);
+    Ok(())
+}
+
+#[rstest]
+fn protocol_mode_start_options_have_correct_flags() -> TestResult {
+    let request = make_protocol_exec_request("sandbox", default_protocol_command())?;
+    let options = build_start_exec_options(&request);
+    assert_protocol_start_options(&options);
+    Ok(())
+}
+
+#[rstest]
+fn protocol_exec_succeeds_end_to_end(runtime: RuntimeFixture) -> TestResult {
+    let runtime_handle = runtime?;
+    let mut client = MockExecClient::new();
+    setup_create_exec_expectation(&mut client, "proto-exec-1", false);
+    setup_start_exec_protocol(&mut client, vec![&b"protocol-output"[..]]);
+    client.expect_resize_exec().never();
+    setup_inspect_exec_once(&mut client, Some(0));
+
+    let request = make_protocol_exec_request("sandbox-proto", default_protocol_command())?;
+    let terminal_size_provider = make_terminal_size_provider(80, 24);
+    execute_and_assert_success(&runtime_handle, &client, &request, &terminal_size_provider);
+    Ok(())
+}
+
+#[rstest]
+fn protocol_exec_returns_nonzero_exit_code(runtime: RuntimeFixture) -> TestResult {
+    let runtime_handle = runtime?;
+    let mut client = MockExecClient::new();
+    setup_create_exec_simple(&mut client, "proto-exec-2");
+    setup_start_exec_protocol(&mut client, vec![]);
+    client.expect_resize_exec().never();
+    setup_inspect_exec_once(&mut client, Some(42));
+
+    let request = make_protocol_exec_request("sandbox-proto", default_protocol_command())?;
+    let result = runtime_handle.block_on(EngineConnector::exec_async(&client, &request));
+    assert_exit_code(result, 42, "protocol exec should succeed");
+    Ok(())
+}
+
+#[rstest]
+fn protocol_mode_rejects_detached_daemon_response(runtime: RuntimeFixture) -> TestResult {
+    let runtime_handle = runtime?;
+    let mut client = MockExecClient::new();
+    setup_create_exec_simple(&mut client, "proto-exec-3");
+    setup_start_exec_protocol_detached_response(&mut client);
+
+    let request = make_protocol_exec_request("sandbox-proto", default_protocol_command())?;
+    let result = runtime_handle.block_on(EngineConnector::exec_async(&client, &request));
+    detached_helpers::assert_exec_failed_with_message(
+        result,
+        "detached start result",
+        "protocol mode should reject detached daemon response",
+    );
+    Ok(())
+}
+
+fn setup_start_exec_protocol_detached_response(client: &mut MockExecClient) {
+    client.expect_start_exec().times(1).returning(|_, options| {
+        assert_eq!(
+            options,
+            Some(StartExecOptions {
+                detach: false,
+                tty: false,
+                output_capacity: None
+            })
+        );
+        Box::pin(async { Ok(bollard::exec::StartExecResults::Detached) })
+    });
+}

--- a/src/engine/connection/exec/tests/protocol_helpers.rs
+++ b/src/engine/connection/exec/tests/protocol_helpers.rs
@@ -23,6 +23,11 @@ fn default_protocol_command() -> Vec<String> {
     ]
 }
 
+fn assert_non_protocol_modes() {
+    assert!(!ExecMode::Attached.is_protocol());
+    assert!(!ExecMode::Detached.is_protocol());
+}
+
 fn setup_start_exec_protocol(client: &mut MockExecClient, output_messages: Vec<&'static [u8]>) {
     client
         .expect_start_exec()
@@ -88,6 +93,11 @@ fn protocol_mode_enforces_tty_false_in_constructor() -> TestResult {
     let request = make_protocol_exec_request("sandbox", default_protocol_command())?;
     assert_protocol_request_properties(&request);
     Ok(())
+}
+
+#[rstest]
+fn non_protocol_modes_do_not_identify_as_protocol() {
+    assert_non_protocol_modes();
 }
 
 fn assert_tty_override_rejected(request: &ExecRequest) {

--- a/tests/bdd_interactive_exec.rs
+++ b/tests/bdd_interactive_exec.rs
@@ -44,3 +44,19 @@ fn execution_fails_when_exit_code_missing(interactive_exec_state: InteractiveExe
 fn attached_execution_with_tty_disabled_succeeds(interactive_exec_state: InteractiveExecState) {
     let _ = interactive_exec_state;
 }
+
+#[scenario(
+    path = "tests/features/interactive_exec.feature",
+    name = "Protocol execution succeeds with tty disabled"
+)]
+fn protocol_execution_succeeds(interactive_exec_state: InteractiveExecState) {
+    let _ = interactive_exec_state;
+}
+
+#[scenario(
+    path = "tests/features/interactive_exec.feature",
+    name = "Protocol execution returns non-zero exit code"
+)]
+fn protocol_execution_returns_non_zero_exit(interactive_exec_state: InteractiveExecState) {
+    let _ = interactive_exec_state;
+}

--- a/tests/bdd_interactive_exec_helpers/steps.rs
+++ b/tests/bdd_interactive_exec_helpers/steps.rs
@@ -152,7 +152,7 @@ fn configure_start_exec_expectation(
     tty_enabled: bool,
 ) {
     match mode {
-        ExecMode::Attached | ExecMode::Protocol => {
+        ExecMode::Attached => {
             client
                 .expect_start_exec()
                 .times(1)
@@ -175,6 +175,27 @@ fn configure_start_exec_expectation(
                         })
                     })
                 });
+        }
+        ExecMode::Protocol => {
+            client.expect_start_exec().times(1).returning(|_, options| {
+                assert_eq!(
+                    options,
+                    Some(bollard::exec::StartExecOptions {
+                        detach: false,
+                        tty: false,
+                        output_capacity: None
+                    })
+                );
+                let output_stream = stream::iter(vec![Ok(LogOutput::StdOut {
+                    message: Vec::from(&b"bdd output"[..]).into(),
+                })]);
+                Box::pin(async move {
+                    Ok(bollard::exec::StartExecResults::Attached {
+                        output: Box::pin(output_stream),
+                        input: Box::pin(tokio::io::sink()),
+                    })
+                })
+            });
         }
         ExecMode::Detached => {
             client.expect_start_exec().times(1).returning(|_, options| {

--- a/tests/bdd_interactive_exec_helpers/steps.rs
+++ b/tests/bdd_interactive_exec_helpers/steps.rs
@@ -210,6 +210,7 @@ fn configure_start_exec_expectation(
                 Box::pin(async { Ok(bollard::exec::StartExecResults::Detached) })
             });
         }
+        _ => panic!("unexpected exec mode in BDD start-exec expectation"),
     }
 }
 
@@ -226,6 +227,7 @@ fn configure_resize_expectation(client: &mut MockExecClient, mode: ExecMode) {
         ExecMode::Detached | ExecMode::Protocol => {
             client.expect_resize_exec().never();
         }
+        _ => panic!("unexpected exec mode in BDD resize expectation"),
     }
 }
 

--- a/tests/bdd_interactive_exec_helpers/steps.rs
+++ b/tests/bdd_interactive_exec_helpers/steps.rs
@@ -36,6 +36,12 @@ fn detached_execution_mode_selected(interactive_exec_state: &InteractiveExecStat
     interactive_exec_state.mode.set(ExecMode::Detached);
 }
 
+#[given("protocol execution mode is selected")]
+fn protocol_execution_mode_selected(interactive_exec_state: &InteractiveExecState) {
+    interactive_exec_state.mode.set(ExecMode::Protocol);
+    interactive_exec_state.tty_enabled.set(false);
+}
+
 #[given("tty allocation is enabled")]
 fn tty_allocation_enabled(interactive_exec_state: &InteractiveExecState) {
     interactive_exec_state.tty_enabled.set(true);
@@ -146,7 +152,7 @@ fn configure_start_exec_expectation(
     tty_enabled: bool,
 ) {
     match mode {
-        ExecMode::Attached => {
+        ExecMode::Attached | ExecMode::Protocol => {
             client
                 .expect_start_exec()
                 .times(1)
@@ -196,7 +202,7 @@ fn configure_resize_expectation(client: &mut MockExecClient, mode: ExecMode) {
                 .times(0..)
                 .returning(|_, _| Box::pin(async { Ok(()) }));
         }
-        ExecMode::Detached => {
+        ExecMode::Detached | ExecMode::Protocol => {
             client.expect_resize_exec().never();
         }
     }

--- a/tests/bdd_orchestration_helpers/steps.rs
+++ b/tests/bdd_orchestration_helpers/steps.rs
@@ -169,7 +169,7 @@ fn configure_create_exec(client: &mut MockOrcExecClient) {
 
 fn configure_start_exec(client: &mut MockOrcExecClient, mode: ExecMode) {
     match mode {
-        ExecMode::Attached => {
+        ExecMode::Attached | ExecMode::Protocol => {
             client.expect_start_exec().times(1).returning(move |_, _| {
                 let output_stream = stream::iter(vec![Ok(LogOutput::StdOut {
                     message: Vec::from(&b"orc output"[..]).into(),
@@ -198,7 +198,7 @@ fn configure_resize(client: &mut MockOrcExecClient, mode: ExecMode) {
                 .times(0..)
                 .returning(|_, _| Box::pin(async { Ok(()) }));
         }
-        ExecMode::Detached => {
+        ExecMode::Detached | ExecMode::Protocol => {
             client.expect_resize_exec().never();
         }
     }

--- a/tests/bdd_orchestration_helpers/steps.rs
+++ b/tests/bdd_orchestration_helpers/steps.rs
@@ -187,6 +187,7 @@ fn configure_start_exec(client: &mut MockOrcExecClient, mode: ExecMode) {
                 Box::pin(async { Ok(bollard::exec::StartExecResults::Detached) })
             });
         }
+        _ => panic!("unexpected exec mode in orchestration start-exec expectation"),
     }
 }
 
@@ -201,6 +202,7 @@ fn configure_resize(client: &mut MockOrcExecClient, mode: ExecMode) {
         ExecMode::Detached | ExecMode::Protocol => {
             client.expect_resize_exec().never();
         }
+        _ => panic!("unexpected exec mode in orchestration resize expectation"),
     }
 }
 

--- a/tests/features/interactive_exec.feature
+++ b/tests/features/interactive_exec.feature
@@ -42,3 +42,19 @@ Feature: Interactive execution
     When execution is requested
     Then execution succeeds
     And reported exit code is 0
+
+  Scenario: Protocol execution succeeds with tty disabled
+    Given protocol execution mode is selected
+    And command is codex app-server --listen stdio
+    And command exit code is 0
+    When execution is requested
+    Then execution succeeds
+    And reported exit code is 0
+
+  Scenario: Protocol execution returns non-zero exit code
+    Given protocol execution mode is selected
+    And command is codex app-server --listen stdio
+    And command exit code is 1
+    When execution is requested
+    Then execution succeeds
+    And reported exit code is 1


### PR DESCRIPTION
## Summary
Introduce a new protocol execution mode that forwards streams like Attached but permanently disables TTY. This mode is intended for non-TTY protocol proxying (e.g. hosting IDEs) and enforces tty = false at construction time. Existing Attached and Detached modes remain unchanged.

## Changes
### Core API
- Add ExecMode::Protocol to src/engine/connection/exec/mod.rs.
- Extend is_attached() to treat Protocol as attached for streaming purposes.
- Add is_protocol() to identify protocol mode.
- Change ExecRequest::new() to set tty = (mode == Attached) instead of mode.is_attached().
- Update with_tty() to disallow overriding tty for Protocol (only Attached can set tty).

### Execution path
- Update dispatch in EngineConnector to treat (ExecMode::Attached | ExecMode::Protocol) identically for StartExecResults::Attached and StartExecResults::Detached where appropriate.
- No changes to Bollard option builders beyond the existing delegation (Protocol uses is_attached() and tty() semantics).

### API surface
- src/api/exec.rs: Document that tty is ignored for Protocol and Detached modes.

### Tests
- Add new protocol-mode unit tests at src/engine/connection/exec/tests/protocol_helpers.rs.
- Wire up tests module in tests/engine/connection/exec/tests.rs.
- Extend BDD tests and helpers to cover protocol mode.
  - New protocol-focused scenarios in tests/features/interactive_exec.feature.
  - New steps: protocol_execution_mode_selected and related expectations in steps.
  - Update protocol-related expectations in tests/bdd_interactive_exec_helpers/steps.rs and tests/bdd_orchestration_helpers/steps.rs.

### Documentation
- docs/podbot-design.md: Update interactive exec semantics to include Protocol mode.
- docs/users-guide.md: Mention ExecMode::Protocol and its use for non-TTY attached execution.
- docs/podbot-roadmap.md: Mark Step 2.5.1 as done.

## Validation
- Run: make check-fmt, make lint, make test, and markdownlint as part of gates.
- New unit tests in protocol_helpers.rs validate:
  - Protocol enforces tty = false in constructor
  - TTY override is rejected for Protocol
  - Correct Bollard Create/Start options for protocol mode
  - End-to-end success/failure paths respect protocol semantics
- Updated BDD scenarios verify protocol execution with exit codes 0 and non-zero.

## Usage
- Construct a protocol-mode exec request:
  let request = ExecRequest::new("container", cmd, ExecMode::Protocol)?;
- tty() will always be false for protocol mode, and protocol streams are attached
  (stdin/stdout/stderr forwarded).
- Example still works with existing Attached/Detached behavior; Protocol augments the set while preserving compatibility.

## Compatibility & migration
- No breaking changes to existing API signatures for ExecMode::Attached or ExecMode::Detached.
- Protocol is an additive public API variant; call sites can opt into protocol mode when non‑TTY protocol proxying is required.

## Rollout plan
- Stage A–G completed in this PR: add protocol variant, wiring, tests, docs, and validation gates.
- No migrations required; library consumers can start using ExecMode::Protocol where appropriate.


◳ Generated by [DevBoxer](https://www.devboxer.com) ◰

---

ℹ️ Tag @devboxerhub to ask questions and address PR feedback

📎 **Task**: https://www.devboxer.com/task/9ee2b21e-2712-4d0f-a674-695bb1625f56

## Summary by Sourcery

Introduce a new protocol execution mode that attaches streams while permanently disabling TTY, and wire it through the exec engine, BDD tests, and documentation.

New Features:
- Add ExecMode::Protocol for attached, non-TTY protocol-safe exec sessions.
- Expose protocol mode through the public exec API, allowing callers to request non-TTY attached execution.

Enhancements:
- Treat protocol mode as attached for stream handling while enforcing tty = false in request construction and configuration.
- Align engine dispatch and orchestration helpers so protocol and attached modes share stream behaviour but differ in TTY and resize handling.

Documentation:
- Document ExecMode::Protocol usage and semantics in the user guide and design docs, including its non-TTY behaviour and relationship to hosting.
- Update the roadmap and add an ExecPlan document to record completion of protocol-safe exec attachment.

Tests:
- Add unit tests for protocol-mode exec covering TTY enforcement, options building, and end-to-end behaviour.
- Extend BDD interactive exec scenarios and step helpers to validate protocol-mode execution and exit-code reporting.