### PR TITLE
Docs: align Podbot MCP wiring, hosted hooks, and prompt validation

### DIFF
--- a/docs/adr-003-define-the-hook-execution-primitive-and-suspend-ack-protocol.md
+++ b/docs/adr-003-define-the-hook-execution-primitive-and-suspend-ack-protocol.md
@@ -159,11 +159,24 @@ Triggered, Executing, Completed, and Aborted.
 ```mermaid
 stateDiagram-v2
     [*] --> Idle
-    Idle --> Triggered : trigger fires\nSessionEvent::HookTriggered emitted\nAgent session suspended
+    Idle --> Triggered : trigger fires
+    note right of Triggered
+        SessionEvent::HookTriggered emitted
+        Agent session suspended
+    end note
     Triggered --> Executing : orchestrator ack (Continue)
     Triggered --> Aborted : orchestrator ack (Abort)
-    Aborted --> [*] : SessionEvent::HookAborted emitted\nTriggering action rolled back\nAgent resumes or session ends
-    Executing --> Completed : hook exits\nSessionEvent::HookCompleted emitted\nAgent execution resumes
+    Aborted --> [*] : terminal abort path
+    note right of Aborted
+        SessionEvent::HookAborted emitted
+        Triggering action rolled back
+        Agent resumes or session ends
+    end note
+    Executing --> Completed : hook exits
+    note right of Completed
+        SessionEvent::HookCompleted emitted
+        Agent execution resumes
+    end note
 ```
 
 _Figure 1: Hook lifecycle state machine from trigger to completion or abort._

--- a/docs/corbusier-conformance-design-for-agents-mcp-wires-and-hooks.md
+++ b/docs/corbusier-conformance-design-for-agents-mcp-wires-and-hooks.md
@@ -2,61 +2,126 @@
 
 ## Executive summary
 
-Corbusier can conform to the Podbot library API surface by treating Podbot as the **single owner of container orchestration and sandbox wiring**, while Corbusier retains **policy, registry, and orchestration authority**. This matches Podbot’s stated dual-delivery model (CLI + embeddable library) and its “stdout protocol-purity” guarantee for hosting mode. citeturn28view0turn25view0
+Corbusier can conform to the Podbot library API surface by treating Podbot as
+the **single owner of container orchestration and sandbox wiring**, while
+Corbusier retains **policy, registry, and orchestration authority**. This
+matches Podbot’s stated dual-delivery model (CLI + embeddable library) and its
+“stdout protocol-purity” guarantee for hosting mode.
+citeturn28view0turn25view0
 
-The highest-impact architectural change is to **split Corbusier’s tool plane into a registry/control plane and a per-workspace “wire” plane**. The Podbot MCP hosting design explicitly recommends that Corbusier remains the policy/registry layer while Podbot owns transport bridging, auth token injection, and lifecycle clean-up, presenting **Streamable HTTP** to the container regardless of upstream source. citeturn25view0turn29search0
+The highest-impact architectural change is to **split Corbusier’s tool plane
+into a registry/control plane and a per-workspace “wire” plane**. The Podbot
+MCP hosting design explicitly recommends that Corbusier remains the
+policy/registry layer while Podbot owns transport bridging, auth token
+injection, and lifecycle clean-up, presenting **Streamable HTTP** to the
+container regardless of upstream source. citeturn25view0turn29search0
 
-Under the user’s hook assumptions, Corbusier must add a **HookCoordinator** that consumes Podbot hook events over a *podbot → orchestrator* channel and deterministically acknowledges them, because Podbot suspends execution until Corbusier acks. (This hook channel is not described in current Podbot docs; it is a new integration requirement and must be specified/implemented explicitly as part of the integration contract.)
+Under the user’s hook assumptions, Corbusier must add a **HookCoordinator**
+that consumes Podbot hook events over a *podbot → orchestrator* channel and
+deterministically acknowledges them, because Podbot suspends execution until
+Corbusier acks. (This hook channel is not described in current Podbot docs; it
+is a new integration requirement and must be specified/implemented explicitly
+as part of the integration contract.)
 
-Finally, to support consistent agent behaviour across backends, Corbusier should introduce a **prompt + skill bundle abstraction** modelled on Anthropic’s “skills as folders with YAML-frontmatter SKILL.md”, with harmonized frontmatter across prompts/bundles/skills and Jinja2 (Goose-style) interpolation, plus a **Podbot `validate_prompt` surface** that reports ignored/rejected capabilities for a target agent runtime. citeturn31view0turn30search15turn30search27
+Finally, to support consistent agent behaviour across backends, Corbusier
+should introduce a **prompt + skill bundle abstraction** modelled on
+Anthropic’s “skills as folders with YAML-frontmatter SKILL.md”, with harmonized
+frontmatter across prompts/bundles/skills and Jinja2 (Goose-style)
+interpolation, plus a **Podbot `validate_prompt` surface** that reports
+ignored/rejected capabilities for a target agent runtime.
+citeturn31view0turn30search15turn30search27
 
 ## Current state and required alignment
 
-Corbusier is organised as hexagonal modules (domain/ports/adapters) with key subsystems including `agent_backend` and `tool_registry`, and an explicit `worker` module. citeturn21view0turn5view0 The roadmap shows that *workspace encapsulation* and a *hook engine* remain planned (not delivered), while the MCP server lifecycle and tool routing portions are already implemented. citeturn24view0turn10view0
+Corbusier is organised as hexagonal modules (domain/ports/adapters) with key
+subsystems including `agent_backend` and `tool_registry`, and an explicit
+`worker` module. citeturn21view0turn5view0 The roadmap shows that
+*workspace encapsulation* and a *hook engine* remain planned (not delivered),
+while the MCP server lifecycle and tool routing portions are already
+implemented. citeturn24view0turn10view0
 
 ### Corbusier tool registry today
 
 Corbusier already models an MCP server registry and lifecycle persistence:
 
-- `mcp_servers` table stores a `transport` JSONB plus lifecycle and health state. citeturn10view0  
-- Tenant scoping is being added via `tenant_id` on `mcp_servers` with composite foreign keys to dependent tables. citeturn10view1  
-- `tool_registry/services` exports a `McpServerLifecycleService` and a `ToolDiscoveryRoutingService`. citeturn18view2turn17view0  
-- Tool-call parameter validation currently uses a lightweight structural checker (object type + required keys) rather than full JSON Schema. citeturn12view1
+- `mcp_servers` table stores a `transport` JSONB plus lifecycle and health
+  state. citeturn10view0
+- Tenant scoping is being added via `tenant_id` on `mcp_servers` with composite
+  foreign keys to dependent tables. citeturn10view1
+- `tool_registry/services` exports a `McpServerLifecycleService` and a
+  `ToolDiscoveryRoutingService`. citeturn18view2turn17view0
+- Tool-call parameter validation currently uses a lightweight structural
+  checker (object type + required keys) rather than full JSON Schema.
+  citeturn12view1
 
-Corbusier’s design document still frames tool hosting as “MCP server hosting with stdio and HTTP+SSE managers” and positions a tool router in Corbusier’s call path. citeturn23view4turn23view2 Its initial lifecycle implementation provides an `InMemoryMcpServerHost` adapter for deterministic tests, which currently appears as the concrete “runtime host” adapter in the repo. citeturn15view4
+Corbusier’s design document still frames tool hosting as “MCP server hosting
+with stdio and HTTP+SSE managers” and positions a tool router in Corbusier’s
+call path. citeturn23view4turn23view2 Its initial lifecycle implementation
+provides an `InMemoryMcpServerHost` adapter for deterministic tests, which
+currently appears as the concrete “runtime host” adapter in the repo.
+citeturn15view4
 
 ### Podbot contract constraints Corbusier must respect
 
-Podbot’s design asserts three constraints that materially affect Corbusier integration:
+Podbot’s design asserts three constraints that materially affect Corbusier
+integration:
 
-- Podbot is **both** CLI and embeddable Rust library; library functions return typed results and must not write directly to stdout/stderr. citeturn28view0  
-- In hosting mode, Podbot must preserve **stdout purity**: container-protocol bytes only, with diagnostics on stderr. citeturn28view0  
-- For ACP hosting, Podbot enforces **capability masking** by rewriting the ACP `initialize` exchange to remove `terminal/*` and `fs/*`, and may reject those calls if attempted. An explicit opt-in may allow delegation. citeturn28view0
+- Podbot is **both** CLI and embeddable Rust library; library functions return
+  typed results and must not write directly to stdout/stderr. citeturn28view0
+- In hosting mode, Podbot must preserve **stdout purity**: container-protocol
+  bytes only, with diagnostics on stderr. citeturn28view0
+- For ACP hosting, Podbot enforces **capability masking** by rewriting the ACP
+  `initialize` exchange to remove `terminal/*` and `fs/*`, and may reject those
+  calls if attempted. An explicit opt-in may allow delegation.
+  citeturn28view0
 
-On workspace strategy, Podbot’s config explicitly supports `workspace.source = github_clone | host_mount`, and defines hard safety requirements for host mounts (canonicalization, allowlisted roots, symlink escape rejection). citeturn28view0
+On workspace strategy, Podbot’s config explicitly supports
+`workspace.source = github_clone | host_mount`, and defines hard safety
+requirements for host mounts (canonicalization, allowlisted roots, symlink
+escape rejection). citeturn28view0
 
 ### MCP hosting alignment target
 
 The Podbot MCP hosting design recommends:
 
 - Corbusier chooses which MCP servers / wires a task may use (policy/registry),
-- Podbot creates “wires”, performs bridging and clean-up, injects the resulting URL + auth material into the agent container,
-- the agent consumes **Streamable HTTP** endpoints, even when the true source is stdio. citeturn25view0turn29search0turn29search7
+- Podbot creates “wires”, performs bridging and clean-up, injects the resulting
+  URL + auth material into the agent container,
+- the agent consumes **Streamable HTTP** endpoints, even when the true source
+  is stdio. citeturn25view0turn29search0turn29search7
 
-This creates a **direct mismatch** with Corbusier’s current “tool registry & router in the call path” mental model: if the agent container talks to MCP wires directly, Corbusier cannot remain the runtime “router” for those tool calls unless Podbot additionally proxies through Corbusier (not described). This is a pivotal open design choice and must be made explicit in the integration design:
+This creates a **direct mismatch** with Corbusier’s current “tool registry &
+router in the call path” mental model: if the agent container talks to MCP
+wires directly, Corbusier cannot remain the runtime “router” for those tool
+calls unless Podbot additionally proxies through Corbusier (not described).
+This is a pivotal open design choice and must be made explicit in the
+integration design:
 
-- **Option A (recommended by Podbot docs):** agent container is the MCP client; Corbusier moves from “tool router” to “tool policy + wire provisioning + audit ingestion”. citeturn25view0  
-- **Option B (legacy Corbusier model):** Corbusier remains the caller; Podbot executes tools inside container and returns results to Corbusier. This would require a Podbot→Corbusier tool-call bridge API that is **unspecified** in current Podbot docs.
+- **Option A (recommended by Podbot docs):** agent container is the MCP client;
+  Corbusier moves from “tool router” to “tool policy + wire provisioning +
+  audit ingestion”. citeturn25view0
+- **Option B (legacy Corbusier model):** Corbusier remains the caller; Podbot
+  executes tools inside container and returns results to Corbusier. This would
+  require a Podbot→Corbusier tool-call bridge API that is **unspecified** in
+  current Podbot docs.
 
-The rest of this document designs for **Option A**, because it matches the primary Podbot MCP hosting design and avoids inventing an unstated Podbot service. Where Option A implies new audit/telemetry pathways, those are called out as required additions.
+The rest of this document designs for **Option A**, because it matches the
+primary Podbot MCP hosting design and avoids inventing an unstated Podbot
+service. Where Option A implies new audit/telemetry pathways, those are called
+out as required additions.
 
 ## Domain model changes
 
-This section defines the concrete models Corbusier needs (or needs to evolve) to align with Podbot’s design surface and the hook assumptions. All type sketches are Rust-like and intentionally “library-facing” (serializable request/response shapes, stable enums).
+This section defines the concrete models Corbusier needs (or needs to evolve)
+to align with Podbot’s design surface and the hook assumptions. All type
+sketches are Rust-like and intentionally “library-facing” (serializable
+request/response shapes, stable enums).
 
 ### AgentRuntimeSpec
 
-Corbusier needs a runtime description that maps cleanly to Podbot’s `agent.kind`, `agent.mode`, and optional custom command fields, plus an env allowlist. citeturn28view0
+Corbusier needs a runtime description that maps cleanly to Podbot’s
+`agent.kind`, `agent.mode`, and optional custom command fields, plus an env
+allowlist. citeturn28view0
 
 ```rust
 /// Corbusier-owned description of the agent runtime to launch via Podbot.
@@ -79,12 +144,18 @@ pub enum AgentMode { Interactive, CodexAppServer, Acp }
 
 Conformance requirements:
 
-- `AgentMode::Acp` must assume that `terminal/*` and `fs/*` are masked by Podbot and are not reliable capabilities. citeturn28view0  
-- `env_allowlist` must be enforced in Corbusier configuration generation, not left as an “advisory” field (Podbot treats this as a contract boundary). citeturn28view0
+- `AgentMode::Acp` must assume that `terminal/*` and `fs/*` are masked by
+  Podbot and are not reliable capabilities. citeturn28view0
+- `env_allowlist` must be enforced in Corbusier configuration generation, not
+  left as an “advisory” field (Podbot treats this as a contract boundary).
+  citeturn28view0
 
 ### WorkspaceSource
 
-Corbusier needs to decide whether Podbot clones into a container-local volume (`github_clone`) or bind-mounts a host workspace (`host_mount`). Podbot’s existing config describes both modes and imposes safety policy for host mounts. citeturn28view0
+Corbusier needs to decide whether Podbot clones into a container-local volume
+(`github_clone`) or bind-mounts a host workspace (`host_mount`). Podbot’s
+existing config describes both modes and imposes safety policy for host mounts.
+citeturn28view0
 
 ```rust
 #[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
@@ -103,11 +174,19 @@ pub enum WorkspaceSource {
 }
 ```
 
-**Unspecified detail:** Corbusier’s repo currently lacks a concrete “workspace manager” implementation in code; the Corbusier design doc contains a conceptual `EncapsulationProvider` but no corresponding crate module. citeturn26view0turn24view0 You must create this module and decide whether Corbusier itself provisions the host workspace directory (recommended for determinism) or delegates cloning to Podbot (aligns with Podbot’s existing `github_clone` flow). citeturn28view0
+**Unspecified detail:** Corbusier’s repo currently lacks a concrete “workspace
+manager” implementation in code; the Corbusier design doc contains a conceptual
+`EncapsulationProvider` but no corresponding crate module.
+citeturn26view0turn24view0 You must create this module and decide whether
+Corbusier itself provisions the host workspace directory (recommended for
+determinism) or delegates cloning to Podbot (aligns with Podbot’s existing
+`github_clone` flow). citeturn28view0
 
 ### McpEndpointSource
 
-Corbusier’s persistent transport model should be updated to match Podbot’s recommended `McpSource` shape: `Stdio`, `StdioContainer`, `StreamableHttp`, with explicit repo volume sharing for helper containers. citeturn25view0
+Corbusier’s persistent transport model should be updated to match Podbot’s
+recommended `McpSource` shape: `Stdio`, `StdioContainer`, `StreamableHttp`,
+with explicit repo volume sharing for helper containers. citeturn25view0
 
 ```rust
 #[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
@@ -134,16 +213,26 @@ pub enum McpEndpointSource {
 pub enum RepoAccess { None, ReadOnly, ReadWrite }
 ```
 
-This aligns with Podbot’s MCP hosting design, where Podbot normalizes the agent-facing transport to Streamable HTTP even when the source is stdio. citeturn25view0turn29search0turn29search7
+This aligns with Podbot’s MCP hosting design, where Podbot normalizes the
+agent-facing transport to Streamable HTTP even when the source is stdio.
+citeturn25view0turn29search0turn29search7
 
-**Required Corbusier schema change:** Corbusier’s existing `mcp_servers.transport` JSONB column is flexible, but the *meaning* of stored transports must evolve: stop modelling “HTTP+SSE” as first-class, and align persisted transport shapes to *source definitions* (stdio/stdio-container/streamable-http), leaving “agent-facing URL” as a per-workspace wire artefact rather than a global server attribute. citeturn10view0turn25view0
+**Required Corbusier schema change:** Corbusier’s existing
+`mcp_servers.transport` JSONB column is flexible, but the *meaning* of stored
+transports must evolve: stop modelling “HTTP+SSE” as first-class, and align
+persisted transport shapes to *source definitions*
+(stdio/stdio-container/streamable-http), leaving “agent-facing URL” as a
+per-workspace wire artefact rather than a global server attribute.
+citeturn10view0turn25view0
 
 ### HookArtifact and HookSubscription
 
 Based on the user’s hook assumptions, Corbusier needs:
 
-- a “hook artefact” model that Podbot can execute (single script OR tar OR optional container image),
-- a subscription model that says which hooks should fire at which points for which workspaces,
+- a “hook artefact” model that Podbot can execute (single script OR tar OR
+  optional container image),
+- a subscription model that says which hooks should fire at which points for
+  which workspaces,
 - a runtime state model for acknowledgements.
 
 ```rust
@@ -187,11 +276,20 @@ pub enum HookTrigger {
 }
 ```
 
-**Unspecified but required:** a concrete mapping between Corbusier’s workflow events and hook triggers (including which component emits them) is not implemented in Corbusier today, and Podbot has no hook spec in its current design docs. You must author a binding spec inside the Corbusier–Podbot integration layer that at minimum defines: trigger names, payload schema, ack semantics, timeout/resume rules, and audit persistence fields.
+**Unspecified but required:** a concrete mapping between Corbusier’s workflow
+events and hook triggers (including which component emits them) is not
+implemented in Corbusier today, and Podbot has no hook spec in its current
+design docs. You must author a binding spec inside the Corbusier–Podbot
+integration layer that at minimum defines: trigger names, payload schema, ack
+semantics, timeout/resume rules, and audit persistence fields.
 
 ### Prompt validation request/response and capability dispositions
 
-Corbusier already has an agent capability model (`supports_streaming`, `supports_tool_calls`, supported content types). citeturn19view0turn3view3 Podbot adds a runtime-enforced capability mask for ACP (`terminal/*`, `fs/*`). citeturn28view0 To unify these, introduce prompt-surface capabilities and dispositions.
+Corbusier already has an agent capability model (`supports_streaming`,
+`supports_tool_calls`, supported content types). citeturn19view0turn3view3
+Podbot adds a runtime-enforced capability mask for ACP (`terminal/*`, `fs/*`).
+citeturn28view0 To unify these, introduce prompt-surface capabilities and
+dispositions.
 
 ```rust
 #[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
@@ -227,19 +325,25 @@ pub enum CapabilityDisposition {
 }
 ```
 
-This is the core of the requested “validate endpoint” behaviour: identify capabilities the prompt requests that a specific agent runtime will ignore (or reject), with explicit reasons.
+This is the core of the requested “validate endpoint” behaviour: identify
+capabilities the prompt requests that a specific agent runtime will ignore (or
+reject), with explicit reasons.
 
 ## Ports, services, and refactors
 
-This section specifies the concrete ports/traits and the refactors needed in Corbusier.
+This section specifies the concrete ports/traits and the refactors needed in
+Corbusier.
 
 ### New ports/traits
 
-Corbusier should add three new port families. They mirror the Podbot recommended responsibility split (policy in Corbusier, wiring in Podbot). citeturn25view0
+Corbusier should add three new port families. They mirror the Podbot
+recommended responsibility split (policy in Corbusier, wiring in Podbot).
+citeturn25view0
 
 #### PodbotAgentLauncher
 
-A Corbusier port that wraps Podbot’s library orchestration into a stable Corbusier interface.
+A Corbusier port that wraps Podbot’s library orchestration into a stable
+Corbusier interface.
 
 ```rust
 #[async_trait::async_trait]
@@ -264,11 +368,13 @@ pub trait PodbotAgentLauncher: Send + Sync {
 }
 ```
 
-This port must be implemented as a Podbot adapter that does not violate Podbot’s stdout-purity and no-direct-print requirements. citeturn28view0
+This port must be implemented as a Podbot adapter that does not violate
+Podbot’s stdout-purity and no-direct-print requirements. citeturn28view0
 
 #### WorkspaceMcpWires
 
-A Corbusier port that calls Podbot’s MCP wire surface (as proposed in Podbot’s MCP hosting design) and returns injection details. citeturn25view0
+A Corbusier port that calls Podbot’s MCP wire surface (as proposed in Podbot’s
+MCP hosting design) and returns injection details. citeturn25view0
 
 ```rust
 #[async_trait::async_trait]
@@ -293,11 +399,16 @@ pub trait WorkspaceMcpWires: Send + Sync {
 }
 ```
 
-This is the key boundary where Corbusier transitions from “MCP server lifecycle manager” to “MCP wire provisioning manager”, matching Podbot’s design. citeturn25view0
+This is the key boundary where Corbusier transitions from “MCP server lifecycle
+manager” to “MCP wire provisioning manager”, matching Podbot’s design.
+citeturn25view0
 
 #### HookCoordinator, HookRegistry, HookPolicyService
 
-Corbusier needs a workflow-governance subsystem consistent with its own design goals (hook engine and encapsulation management appear as planned features). citeturn23view1turn24view0 Under the user’s hook assumptions, HookCoordinator must also coordinate acknowledgements to Podbot.
+Corbusier needs a workflow-governance subsystem consistent with its own design
+goals (hook engine and encapsulation management appear as planned features).
+citeturn23view1turn24view0 Under the user’s hook assumptions,
+HookCoordinator must also coordinate acknowledgements to Podbot.
 
 ```rust
 #[async_trait::async_trait]
@@ -328,27 +439,46 @@ pub trait HookCoordinator: Send + Sync {
 }
 ```
 
-**Unspecified detail:** the Podbot hook message schema and transport (“podbot→orchestrator channel”) do not exist in current Podbot docs. This must be implemented either as a typed callback channel in the embedding library or an out-of-band transport (e.g. UDS) for CLI mode. Either way, it must not violate Podbot hosting stdout purity. citeturn28view0
+**Unspecified detail:** the Podbot hook message schema and transport
+(“podbot→orchestrator channel”) do not exist in current Podbot docs. This must
+be implemented either as a typed callback channel in the embedding library or
+an out-of-band transport (e.g. UDS) for CLI mode. Either way, it must not
+violate Podbot hosting stdout purity. citeturn28view0
 
 ### Lifecycle and service refactors
 
 #### Tool registry lifecycle split
 
-Currently, Corbusier’s `tool_registry/services` exports `McpServerLifecycleService` and `ToolDiscoveryRoutingService`. citeturn18view2 Corbusier must split “server definition lifecycle” from “workspace wiring lifecycle”:
+Currently, Corbusier’s `tool_registry/services` exports
+`McpServerLifecycleService` and `ToolDiscoveryRoutingService`.
+citeturn18view2 Corbusier must split “server definition lifecycle” from
+“workspace wiring lifecycle”:
 
-- **Keep:** `McpServerLifecycleService` as the CRUD/health layer for globally registered MCP server *definitions* (sources), stored in `mcp_servers.transport`. citeturn10view0turn18view2  
-- **Add:** `WorkspaceMcpWireService` as the per-workspace provisioning layer that calls Podbot to create wires and persists the returned Streamable HTTP endpoints by workspace. citeturn25view0turn29search0  
-- **Change:** `ToolDiscoveryRoutingService` should no longer assume Corbusier is the runtime invoker for containerised agents (Option A). Instead it becomes:
+- **Keep:** `McpServerLifecycleService` as the CRUD/health layer for globally
+  registered MCP server *definitions* (sources), stored in
+  `mcp_servers.transport`. citeturn10view0turn18view2
+- **Add:** `WorkspaceMcpWireService` as the per-workspace provisioning layer
+  that calls Podbot to create wires and persists the returned Streamable HTTP
+  endpoints by workspace. citeturn25view0turn29search0
+- **Change:** `ToolDiscoveryRoutingService` should no longer assume Corbusier
+  is the runtime invoker for containerised agents (Option A). Instead it
+  becomes:
   - a “catalogue service” used to materialize tool lists for UI/audit, and/or
-  - a “bootstrap tool manifest builder” for agents (by creating wires and passing endpoints to agent startup).
+  - a “bootstrap tool manifest builder” for agents (by creating wires and
+    passing endpoints to agent startup).
 
-This refactor also aligns with Corbusier’s design doc, which already anticipates a workspace manager and Podbot adapter, but currently only at the conceptual level. citeturn26view0turn24view0
+This refactor also aligns with Corbusier’s design doc, which already
+anticipates a workspace manager and Podbot adapter, but currently only at the
+conceptual level. citeturn26view0turn24view0
 
 #### Workspace-wire service & schema
 
 Introduce new persistent entities:
 
-- `workspaces` (or `workspace_runtimes`) that identifies a Podbot workspace / volume and correlates to `task_id` and possibly `conversation_id`. (Corbusier already has task lifecycle and agent sessions/handoffs persistence patterns.) citeturn24view0turn10view2  
+- `workspaces` (or `workspace_runtimes`) that identifies a Podbot workspace /
+  volume and correlates to `task_id` and possibly `conversation_id`. (Corbusier
+  already has task lifecycle and agent sessions/handoffs persistence patterns.)
+  citeturn24view0turn10view2
 - `workspace_mcp_wires` with:
   - `workspace_id`
   - `wire_name` (stable name referenced by prompts)
@@ -357,55 +487,75 @@ Introduce new persistent entities:
   - `headers` (auth headers returned from Podbot)
   - `status` and timestamps
 
-This matches Podbot’s contract: Corbusier says *what to wire*; Podbot returns *how the container reaches it* (URL + headers). citeturn25view0turn29search0
+This matches Podbot’s contract: Corbusier says *what to wire*; Podbot returns
+*how the container reaches it* (URL + headers). citeturn25view0turn29search0
 
 #### Hook coordinator state machine
 
-Corbusier must store hook execution and acknowledgement for auditability (consistent with its broader audit goals in tool calls and agent handoffs). citeturn23view4turn10view2 A concrete minimal state machine for hook gating:
+Corbusier must store hook execution and acknowledgement for auditability
+(consistent with its broader audit goals in tool calls and agent handoffs).
+citeturn23view4turn10view2 A concrete minimal state machine for hook gating:
 
 - `Pending` (hook requested by Podbot, not yet authorised)
 - `Authorised` or `Denied` (after HookPolicyService decision)
 - `Acked` (ack delivered to Podbot)
-- `Completed` / `Failed` (if Podbot also emits completion events; **unspecified**)
+- `Completed` / `Failed` (if Podbot also emits completion events;
+  **unspecified**)
 
-Corbusier must guarantee idempotent ack behaviour: repeated hook request messages (e.g. after restart) must not cause duplicate approvals.
+Corbusier must guarantee idempotent ack behaviour: repeated hook request
+messages (e.g. after restart) must not cause duplicate approvals.
 
 ### Concrete Corbusier file changes mapping
 
-The following table maps existing Corbusier files (plus a few “new file” touchpoints) to required refactors. File existence and module layout are derived from the current repository tree. citeturn5view0turn11view0turn19view0turn22view0
+The following table maps existing Corbusier files (plus a few “new file”
+touchpoints) to required refactors. File existence and module layout are
+derived from the current repository tree.
+citeturn5view0turn11view0turn19view0turn22view0
 
-| File path | Current responsibility | Proposed change | Risk / effort |
-|---|---|---|---|
-| `src/lib.rs` | Declares top-level modules (`agent_backend`, `tool_registry`, etc.). citeturn21view0 | Add new modules: `workspace` (encapsulation), `hook_engine`, `prompt`, `bundle`, `podbot_adapter`. | Med |
-| `src/main.rs` | Stub entry point. citeturn21view1 | Replace with real server/daemon bootstrap only when Corbusier’s HTTP/event surfaces are delivered; not strictly required for library-integration work. | Low |
-| `docs/corbusier-design.md` | High-level architecture incl. workspace management and `EncapsulationProvider` concept. citeturn26view0turn23view4 | Update to reflect Podbot MCP wire model (Streamable HTTP), hook ack channel, prompt validation surface, and tool router role shift (Option A). | Med |
-| `docs/roadmap.md` | Delivery plan; workspace encapsulation and hook engine remain planned. citeturn24view0 | Add explicit milestones for Podbot wire provisioning + hook coordinator + prompt validation. | Low |
-| `src/tool_registry/domain/transport.rs` | Transport modelling for MCP server connectivity (currently includes legacy shapes such as HTTP+SSE). citeturn3view0turn23view4 | Replace/alias to `McpEndpointSource` (`Stdio`, `StdioContainer`, `StreamableHttp`) and treat Streamable HTTP as the default agent-facing injection. | High |
-| `src/tool_registry/ports/host.rs` | Defines MCP server hosting port (start/stop/health/list_tools/call_tool). citeturn3view1turn23view4 | Deprecate for Podbot-hosted agents; keep only for tests/local. Introduce new ports `WorkspaceMcpWires` and (optionally) `McpCatalogReader` for registry UI. | High |
-| `src/tool_registry/services/lifecycle/mod.rs` | Service orchestration for MCP server lifecycle. citeturn3view2turn18view2 | Split: definition lifecycle vs workspace-wire lifecycle. Move wire operations out of “server lifecycle” into `workspace/wires.rs` service. | High |
-| `src/tool_registry/services/discovery/log_and_audit.rs` | Tool discovery logging/audit capture. citeturn18view0 | Convert to “registry audit” and “wire provisioning audit” for Option A; add ingestion hooks for Podbot-provided tool call logs if implemented (unspecified). | Med/High |
-| `src/tool_registry/domain/validation.rs` | Lightweight schema validation for tool parameters. citeturn12view1 | Extend or reuse for prompt input schema validation; consider adding full JSON Schema later (explicitly assess). | Med |
-| `src/tool_registry/adapters/runtime.rs` | In-memory MCP host adapter for tests. citeturn15view4 | Keep; add Podbot-wire fakes for integration tests; do not overload this module with real Podbot wiring. | Low/Med |
-| `migrations/..._add_mcp_servers_table/up.sql` | Adds `mcp_servers` with `transport` JSONB. citeturn10view0 | New migrations: `workspace_runtimes`, `workspace_mcp_wires`, `hook_executions`, prompt/bundle registries if persisted. | Med |
-| `src/agent_backend/domain/capabilities.rs` | Agent capability flags (`supports_streaming`, `supports_tool_calls`, content types). citeturn3view3turn19view0 | Extend with `PromptSurfaceCapabilities` and ACP-related constraints; create capability-to-disposition mapping for validation. | Med |
-| `src/agent_backend/services/registry.rs` | Backend registry and discovery. citeturn20view0turn24view0 | Add runtime-spec resolution: map backend registry entries to `AgentRuntimeSpec` and launch via Podbot when backend is “podbot-hosted”. | Med |
-| `src/worker/*` and `src/bin/pg_worker.rs` | Background work infrastructure. citeturn22view0turn5view3 | Add background sweeps: stale wire cleanup, hook timeout handling, and possibly Podbot reconcile loops. | Med |
+| File path                                               | Current responsibility                                                                                                                     | Proposed change                                                                                                                                                      | Risk / effort |
+| ------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------- |
+| `src/lib.rs`                                            | Declares top-level modules (`agent_backend`, `tool_registry`, etc.). citeturn21view0                                                    | Add new modules: `workspace` (encapsulation), `hook_engine`, `prompt`, `bundle`, `podbot_adapter`.                                                                   | Med           |
+| `src/main.rs`                                           | Stub entry point. citeturn21view1                                                                                                       | Replace with real server/daemon bootstrap only when Corbusier’s HTTP/event surfaces are delivered; not strictly required for library-integration work.               | Low           |
+| `docs/corbusier-design.md`                              | High-level architecture incl. workspace management and `EncapsulationProvider` concept. citeturn26view0turn23view4                     | Update to reflect Podbot MCP wire model (Streamable HTTP), hook ack channel, prompt validation surface, and tool router role shift (Option A).                       | Med           |
+| `docs/roadmap.md`                                       | Delivery plan; workspace encapsulation and hook engine remain planned. citeturn24view0                                                  | Add explicit milestones for Podbot wire provisioning + hook coordinator + prompt validation.                                                                         | Low           |
+| `src/tool_registry/domain/transport.rs`                 | Transport modelling for MCP server connectivity (currently includes legacy shapes such as HTTP+SSE). citeturn3view0turn23view4         | Replace/alias to `McpEndpointSource` (`Stdio`, `StdioContainer`, `StreamableHttp`) and treat Streamable HTTP as the default agent-facing injection.                  | High          |
+| `src/tool_registry/ports/host.rs`                       | Defines MCP server hosting port (start/stop/health/list_tools/call_tool). citeturn3view1turn23view4                                    | Deprecate for Podbot-hosted agents; keep only for tests/local. Introduce new ports `WorkspaceMcpWires` and (optionally) `McpCatalogReader` for registry UI.          | High          |
+| `src/tool_registry/services/lifecycle/mod.rs`           | Service orchestration for MCP server lifecycle. citeturn3view2turn18view2                                                              | Split: definition lifecycle vs workspace-wire lifecycle. Move wire operations out of “server lifecycle” into `workspace/wires.rs` service.                           | High          |
+| `src/tool_registry/services/discovery/log_and_audit.rs` | Tool discovery logging/audit capture. citeturn18view0                                                                                   | Convert to “registry audit” and “wire provisioning audit” for Option A; add ingestion hooks for Podbot-provided tool call logs if implemented (unspecified).         | Med/High      |
+| `src/tool_registry/domain/validation.rs`                | Lightweight schema validation for tool parameters. citeturn12view1                                                                      | Extend or reuse for prompt input schema validation; consider adding full JSON Schema later (explicitly assess).                                                      | Med           |
+| `src/tool_registry/adapters/runtime.rs`                 | In-memory MCP host adapter for tests. citeturn15view4                                                                                   | Keep; add Podbot-wire fakes for integration tests; do not overload this module with real Podbot wiring.                                                              | Low/Med       |
+| `migrations/..._add_mcp_servers_table/up.sql`           | Adds `mcp_servers` with `transport` JSONB. citeturn10view0                                                                              | New migrations: `workspace_runtimes`, `workspace_mcp_wires`, `hook_executions`, prompt/bundle registries if persisted.                                               | Med           |
+| `src/agent_backend/domain/capabilities.rs`              | Agent capability flags (`supports_streaming`, `supports_tool_calls`, content types). citeturn3view3turn19view0                         | Extend with `PromptSurfaceCapabilities` and ACP-related constraints; create capability-to-disposition mapping for validation.                                        | Med           |
+| `src/agent_backend/services/registry.rs`                | Backend registry and discovery. citeturn20view0turn24view0                                                                             | Add runtime-spec resolution: map backend registry entries to `AgentRuntimeSpec` and launch via Podbot when backend is “podbot-hosted”.                               | Med           |
+| `src/worker/*` and `src/bin/pg_worker.rs`               | Background work infrastructure. citeturn22view0turn5view3                                                                              | Add background sweeps: stale wire cleanup, hook timeout handling, and possibly Podbot reconcile loops.                                                               | Med           |
 
 ## Prompt, bundles, and validation
 
 This section proposes a concrete prompt/bundle system that aligns with:
 
-- Anthropic’s skill structure: “skills are folders” with a `SKILL.md` containing YAML frontmatter and instructions (minimum frontmatter keys: `name`, `description`). citeturn31view0  
-- Claude Code’s use of Markdown + YAML frontmatter for other agent-facing instruction artefacts (e.g. output styles). citeturn30search15  
-- Jinja2 template syntax for interpolation (`{{ ... }}` and `{% ... %}`), which Goose-style templating uses. citeturn30search27
+- Anthropic’s skill structure: “skills are folders” with a `SKILL.md`
+  containing YAML frontmatter and instructions (minimum frontmatter keys:
+  `name`, `description`). citeturn31view0
+- Claude Code’s use of Markdown + YAML frontmatter for other agent-facing
+  instruction artefacts (e.g. output styles). citeturn30search15
+- Jinja2 template syntax for interpolation (`{{ ... }}` and `{% ... %}`), which
+  Goose-style templating uses. citeturn30search27
 
 ### File taxonomy
 
-1. **Skill** (Anthropic-compatible): directory `skills/<skill-id>/SKILL.md` + optional supporting files (`scripts/*`, `references/*`, etc.). citeturn31view0  
-2. **Prompt** (Corbusier/Podbot-compatible): a Markdown prompt that can be run by an agent, with YAML frontmatter harmonized with SKILL.md.  
-3. **Bundle**: a distributable package of skills + prompts + optional MCP server definitions + optional hook artefacts.
+1. **Skill** (Anthropic-compatible): directory `skills/<skill-id>/SKILL.md` +
+   optional supporting files (`scripts/*`, `references/*`, etc.).
+   citeturn31view0
+2. **Prompt** (Corbusier/Podbot-compatible): a Markdown prompt that can be run
+   by an agent, with YAML frontmatter harmonized with SKILL.md.
+3. **Bundle**: a distributable package of skills + prompts + optional MCP
+   server definitions + optional hook artefacts.
 
-**Important design choice:** Keep SKILL.md *compatible* with Anthropic by limiting required frontmatter to `name` and `description`, while permitting additional namespaced keys under `x-corbusier`, `x-podbot`, etc. This preserves progressive disclosure conventions while enabling extra metadata. citeturn31view0turn30search3
+**Important design choice:** Keep SKILL.md *compatible* with Anthropic by
+limiting required frontmatter to `name` and `description`, while permitting
+additional namespaced keys under `x-corbusier`, `x-podbot`, etc. This preserves
+progressive disclosure conventions while enabling extra metadata.
+citeturn31view0turn30search3
 
 ### Harmonized frontmatter schema
 
@@ -478,11 +628,14 @@ Working directory: `{{ workspace.container_path }}`
    - a validation plan
 ```
 
-Jinja2 syntax and semantics for `{{ ... }}` substitution and `{% ... %}` control flow are documented in the upstream Jinja template reference. citeturn30search27
+Jinja2 syntax and semantics for `{{ ... }}` substitution and `{% ... %}`
+control flow are documented in the upstream Jinja template reference.
+citeturn30search27
 
 ### Skill bundle abstraction
 
-Model the bundle after Anthropic’s “skills as folders”, but extend it to include *prompts*, *MCP definitions*, and *hook artefacts*.
+Model the bundle after Anthropic’s “skills as folders”, but extend it to
+include *prompts*, *MCP definitions*, and *hook artefacts*.
 
 Bundle layout:
 
@@ -536,7 +689,11 @@ hooks:
     workspace_access: read_only
 ```
 
-**Unspecified detail:** Whether Corbusier persists bundles/prompts in its DB versus loading from a workspace filesystem is not currently defined in Corbusier. Given Podbot’s host-mount safety model, a practical first iteration is “bundle lives in repo, Corbusier parses it from the mounted workspace”, then move to a curated registry later. citeturn28view0turn24view0
+**Unspecified detail:** Whether Corbusier persists bundles/prompts in its DB
+versus loading from a workspace filesystem is not currently defined in
+Corbusier. Given Podbot’s host-mount safety model, a practical first iteration
+is “bundle lives in repo, Corbusier parses it from the mounted workspace”, then
+move to a curated registry later. citeturn28view0turn24view0
 
 ### Podbot `validate_prompt` endpoint
 
@@ -545,7 +702,10 @@ Podbot should expose validation as:
 - a library function for embedders (Corbusier),
 - optionally, a CLI `podbot validate-prompt` that emits JSON for operators/CI.
 
-Validation must at minimum enforce the ACP masking reality: if the prompt requires terminal or fs ACP capabilities, validation should report them as **ignored** or **rejected** depending on whether the prompt marked them as required. citeturn28view0
+Validation must at minimum enforce the ACP masking reality: if the prompt
+requires terminal or fs ACP capabilities, validation should report them as
+**ignored** or **rejected** depending on whether the prompt marked them as
+required. citeturn28view0
 
 Sample request:
 
@@ -600,70 +760,107 @@ Sample response (capability ignored but prompt remains valid):
 ### Security and trust boundary changes
 
 1. **Workspace access and host mounts**  
-   If Corbusier uses `host_mount`, it must implement Podbot’s required path policy (canonicalize, allowlist roots, reject symlink escapes). Enforcement cannot be left solely to operators. citeturn28view0
+   If Corbusier uses `host_mount`, it must implement Podbot’s required path
+   policy (canonicalize, allowlist roots, reject symlink escapes). Enforcement
+   cannot be left solely to operators. citeturn28view0
 
 2. **Environment secret passthrough**  
-   Corbusier must treat `env_allowlist` as a hard gate for both agent runtime and hooks. Podbot’s design explicitly separates “credential injection” from “env allowlist” and requires secret redaction. citeturn28view0
+   Corbusier must treat `env_allowlist` as a hard gate for both agent runtime
+   and hooks. Podbot’s design explicitly separates “credential injection” from
+   “env allowlist” and requires secret redaction. citeturn28view0
 
 3. **MCP transport framing and stdout purity**  
-   For stdio MCP sources, MCP requires newline-delimited JSON-RPC messages with no embedded newlines, and no non-protocol bytes on stdout. citeturn29search7turn29search1 Podbot’s hosting design mirrors this “protocol purity” goal for its own hosting mode. citeturn28view0turn25view0  
-   This implies:
+   For stdio MCP sources, MCP requires newline-delimited JSON-RPC messages with
+   no embedded newlines, and no non-protocol bytes on stdout.
+   citeturn29search7turn29search1 Podbot’s hosting design mirrors this
+   “protocol purity” goal for its own hosting mode.
+   citeturn28view0turn25view0 This implies:
    - do not log structured diagnostics onto MCP stdio streams,
    - isolate tool/hook logs into stderr or structured side channels.
 
 4. **Repo access for helper containers**  
-   Podbot’s MCP hosting design requires explicit `RepoAccess` for helper containers, defaulting to `None`, and distinguishes helper-container sharing from the agent container’s own workspace mount. citeturn25view0 Corbusier must surface this in policy/UI and persist it in the server definition schema.
+   Podbot’s MCP hosting design requires explicit `RepoAccess` for helper
+   containers, defaulting to `None`, and distinguishes helper-container sharing
+   from the agent container’s own workspace mount. citeturn25view0 Corbusier
+   must surface this in policy/UI and persist it in the server definition
+   schema.
 
 5. **ACP delegation**  
-   Corbusier must not rely on ACP’s “IDE-host tools” for file system or terminal operations when using Podbot-hosted agents; Podbot masks them by default. Any override to allow ACP delegation is a trust-boundary change that Corbusier should treat as policy-controlled and auditable. citeturn28view0
+   Corbusier must not rely on ACP’s “IDE-host tools” for file system or
+   terminal operations when using Podbot-hosted agents; Podbot masks them by
+   default. Any override to allow ACP delegation is a trust-boundary change
+   that Corbusier should treat as policy-controlled and auditable.
+   citeturn28view0
 
 ### Migration plan
 
-A staged rollout should preserve functioning parts of Corbusier’s current tool registry while introducing Podbot-wired operation safely.
+A staged rollout should preserve functioning parts of Corbusier’s current tool
+registry while introducing Podbot-wired operation safely.
 
 - **Backwards compatibility adapters**  
-  Corbusier currently models transport in `tool_registry/domain/transport.rs` with historical variants; add a compatibility layer:
-  - map legacy `http_sse` records to `streamable_http` where possible (Streamable HTTP may optionally employ SSE for streaming, but the defining contract is Streamable HTTP). citeturn29search0turn25view0  
-  - keep legacy parsing to avoid migration failures, but re-serialize to the new source model on update.
+  Corbusier currently models transport in `tool_registry/domain/transport.rs`
+  with historical variants; add a compatibility layer:
+  - map legacy `http_sse` records to `streamable_http` where possible
+    (Streamable HTTP may optionally employ SSE for streaming, but the defining
+    contract is Streamable HTTP). citeturn29search0turn25view0  
+  - keep legacy parsing to avoid migration failures, but re-serialize to the
+    new source model on update.
 
 - **Legacy SSE adapter**  
-  If Corbusier currently expects SSE as a first-class transport, treat it as deprecated and only supported via bridging layers (Podbot can optionally use SSE within Streamable HTTP; Corbusier should not model SSE as its own stable transport). citeturn29search0turn25view0  
-  Any dedicated “SSE-only” support should be explicitly labelled legacy and isolated behind an adapter boundary.
+  If Corbusier currently expects SSE as a first-class transport, treat it as
+  deprecated and only supported via bridging layers (Podbot can optionally use
+  SSE within Streamable HTTP; Corbusier should not model SSE as its own stable
+  transport). citeturn29search0turn25view0 Any dedicated “SSE-only” support
+  should be explicitly labelled legacy and isolated behind an adapter boundary.
 
 - **Staged rollout**  
-  1) Ship schema + domain-type changes; keep existing lifecycle tests green (using in-memory host). citeturn15view4turn10view0  
-  2) Add Podbot-wire provisioning for one “golden path” MCP server and one workspace strategy (likely host_mount). citeturn28view0turn25view0  
-  3) Enable prompt/bundle parsing and validation in “warn-only” mode (diagnostics logged/audited but not blocking).  
+  1) Ship schema + domain-type changes; keep existing lifecycle tests green
+     (using in-memory host). citeturn15view4turn10view0  
+  2) Add Podbot-wire provisioning for one “golden path” MCP server and one
+     workspace strategy (likely host_mount). citeturn28view0turn25view0  
+  3) Enable prompt/bundle parsing and validation in “warn-only” mode
+     (diagnostics logged/audited but not blocking).  
   4) Enforce policy gates and hook acknowledgements in “block” mode.
 
 ### Tests and QA requirements
 
-Corbusier already emphasises deterministic testing via in-memory adapters and structured audit trails. citeturn15view4turn23view4 Extend this with:
+Corbusier already emphasises deterministic testing via in-memory adapters and
+structured audit trails. citeturn15view4turn23view4 Extend this with:
 
 - **Unit tests**
   - transport conversion: legacy → new `McpEndpointSource`
   - prompt parsing + frontmatter validation
-  - capability disposition mapping (ACP masked capabilities must produce deterministic diagnostics) citeturn28view0
+  - capability disposition mapping (ACP masked capabilities must produce
+    deterministic diagnostics) citeturn28view0
 
 - **Integration tests**
-  - `WorkspaceMcpWires` fake that simulates Podbot returning Streamable HTTP endpoints and headers (URL + auth). citeturn25view0turn29search0
-  - hook coordinator idempotency: duplicate hook requests after restart must not double-ack.
+  - `WorkspaceMcpWires` fake that simulates Podbot returning Streamable HTTP
+    endpoints and headers (URL + auth). citeturn25view0turn29search0
+  - hook coordinator idempotency: duplicate hook requests after restart must
+    not double-ack.
 
 - **E2E tests (requires real Podbot + container engine)**
   - create workspace (host mount), create 2 MCP wires, launch ACP agent, ensure:
     - terminal/fs capabilities are masked (validate_prompt warns appropriately),
     - hooks suspend and resume correctly across ack,
-    - failure/restart scenario: Corbusier restarts mid-hook; it resumes and acks exactly once.
+    - failure/restart scenario: Corbusier restarts mid-hook; it resumes and
+      acks exactly once.
 
 ### Documentation and roadmap updates
 
-Corbusier documentation must reflect the doctrinal shift where Podbot owns runtime mechanics:
+Corbusier documentation must reflect the doctrinal shift where Podbot owns
+runtime mechanics:
 
-- Update Corbusier design doc sections describing tool hosting and workspace encapsulation, replacing “HTTP+SSE manager” framing with “Podbot MCP wires presenting Streamable HTTP to agent containers”. citeturn23view4turn25view0turn29search0  
+- Update Corbusier design doc sections describing tool hosting and workspace
+  encapsulation, replacing “HTTP+SSE manager” framing with “Podbot MCP wires
+  presenting Streamable HTTP to agent containers”.
+  citeturn23view4turn25view0turn29search0
 - Update Corbusier roadmap to include:
-  - Podbot wire provisioning milestone (under encapsulation/workspace management),
+  - Podbot wire provisioning milestone (under encapsulation/workspace
+    management),
   - hook coordinator + ack loop milestone (hook engine),
-  - prompt validation milestone (external interface + governance). citeturn24view0
+  - prompt validation milestone (external interface + governance).
+    citeturn24view0
 
 ### Implementation timeline
 
@@ -697,7 +894,10 @@ Docs + roadmap updates [L]                :e2, after d3, 7d
 
 ### Hook protocol message flow
 
-This sequence diagram implements the required “Podbot sends hook messages; execution suspends until Corbusier acknowledges” assumption, without violating Podbot stdout purity (hook events travel over a dedicated library event channel, not stdout). citeturn28view0
+This sequence diagram implements the required “Podbot sends hook messages;
+execution suspends until Corbusier acknowledges” assumption, without violating
+Podbot stdout purity (hook events travel over a dedicated library event
+channel, not stdout). citeturn28view0
 
 ```mermaid
 sequenceDiagram
@@ -706,23 +906,33 @@ sequenceDiagram
     participant C as Corbusier (orchestrator)
     participant H as HookPolicyService
 
-    Note over P,A: Agent running; Podbot mediates container lifecycle
-    P->>C: HookRequested{hook_id, trigger, workspace_id, access_mode, artifact_ref}
-    Note over P: Podbot suspends execution until ack (requirement)
-    C->>H: authorize_hook(request)
-    H-->>C: decision=Allow|Deny (+reason)
-    C-->>P: HookAck{hook_id, decision, correlation_id}
+    Note over P,A: Agent running
+    Note over P,A: Podbot mediates container lifecycle
+    P->>C: HookRequested
+    Note over P: Podbot suspends execution until ack
+    C->>H: authorize_hook
+    H-->>C: decision allow or deny
+    C-->>P: HookAck
     alt decision=Allow
-        P->>P: execute hook (script/tar/image) with r/o or r/w workspace mount
-        P->>C: HookCompleted{hook_id, status, exit_code, logs_ref} (optional/unspecified)
+        P->>P: execute hook with explicit workspace mount policy
+        P->>C: HookCompleted
     else decision=Deny
-        P->>C: HookSkipped{hook_id, reason} (optional/unspecified)
+        P->>C: HookSkipped
     end
     Note over P,A: Podbot resumes agent execution after ack
 ```
 
-**Unspecified but necessary additions:** the “HookCompleted/HookSkipped” messages and their payload fields are not part of current Podbot docs; include them only if you choose to require post-hook auditing and failure propagation beyond the single ack gate.
+**Unspecified but necessary additions:** the “HookCompleted/HookSkipped”
+messages and their payload fields are not part of current Podbot docs; include
+them only if you choose to require post-hook auditing and failure propagation
+beyond the single ack gate.
 
----
+______________________________________________________________________
 
-This design deliberately confines new “runtime privilege” (container wiring, tool bridging, hook execution) to Podbot, while evolving Corbusier into a policy-driven orchestrator that provisions workspaces and wires, validates prompts/bundles against agent runtimes, and controls governance hooks via explicit acknowledgements—matching the primary Podbot design intent and MCP transport requirements. citeturn25view0turn28view0turn29search0turn29search7turn31view0
+This design deliberately confines new “runtime privilege” (container wiring,
+tool bridging, hook execution) to Podbot, while evolving Corbusier into a
+policy-driven orchestrator that provisions workspaces and wires, validates
+prompts/bundles against agent runtimes, and controls governance hooks via
+explicit acknowledgements—matching the primary Podbot design intent and MCP
+transport requirements.
+citeturn25view0turn28view0turn29search0turn29search7turn31view0

--- a/docs/corbusier-conformance-design-for-agents-mcp-wires-and-hooks.md
+++ b/docs/corbusier-conformance-design-for-agents-mcp-wires-and-hooks.md
@@ -7,14 +7,13 @@ the **single owner of container orchestration and sandbox wiring**, while
 Corbusier retains **policy, registry, and orchestration authority**. This
 matches Podbot’s stated dual-delivery model (CLI + embeddable library) and its
 “stdout protocol-purity” guarantee for hosting mode.
-citeturn28view0turn25view0
 
 The highest-impact architectural change is to **split Corbusier’s tool plane
 into a registry/control plane and a per-workspace “wire” plane**. The Podbot
 MCP hosting design explicitly recommends that Corbusier remains the
 policy/registry layer while Podbot owns transport bridging, auth token
 injection, and lifecycle clean-up, presenting **Streamable HTTP** to the
-container regardless of upstream source. citeturn25view0turn29search0
+container regardless of upstream source.
 
 Under the user’s hook assumptions, Corbusier must add a **HookCoordinator**
 that consumes Podbot hook events over a *podbot → orchestrator* channel and
@@ -27,39 +26,35 @@ Finally, to support consistent agent behaviour across backends, Corbusier
 should introduce a **prompt + skill bundle abstraction** modelled on
 Anthropic’s “skills as folders with YAML-frontmatter SKILL.md”, with harmonized
 frontmatter across prompts/bundles/skills and Jinja2 (Goose-style)
-interpolation, plus a **Podbot `validate_prompt` surface** that reports
-ignored/rejected capabilities for a target agent runtime.
-citeturn31view0turn30search15turn30search27
+interpolation, plus a **proposed Podbot `validate_prompt` surface** that
+reports ignored/rejected capabilities for a target agent runtime.
 
 ## Current state and required alignment
 
-Corbusier is organised as hexagonal modules (domain/ports/adapters) with key
+Corbusier is organized as hexagonal modules (domain/ports/adapters) with key
 subsystems including `agent_backend` and `tool_registry`, and an explicit
-`worker` module. citeturn21view0turn5view0 The roadmap shows that
-*workspace encapsulation* and a *hook engine* remain planned (not delivered),
-while the MCP server lifecycle and tool routing portions are already
-implemented. citeturn24view0turn10view0
+`worker` module. The roadmap shows that *workspace encapsulation* and a *hook
+engine* remain planned (not delivered), while the MCP server lifecycle and tool
+routing portions are already implemented.
 
 ### Corbusier tool registry today
 
 Corbusier already models an MCP server registry and lifecycle persistence:
 
 - `mcp_servers` table stores a `transport` JSONB plus lifecycle and health
-  state. citeturn10view0
+  state.
 - Tenant scoping is being added via `tenant_id` on `mcp_servers` with composite
-  foreign keys to dependent tables. citeturn10view1
+  foreign keys to dependent tables.
 - `tool_registry/services` exports a `McpServerLifecycleService` and a
-  `ToolDiscoveryRoutingService`. citeturn18view2turn17view0
+  `ToolDiscoveryRoutingService`.
 - Tool-call parameter validation currently uses a lightweight structural
   checker (object type + required keys) rather than full JSON Schema.
-  citeturn12view1
 
 Corbusier’s design document still frames tool hosting as “MCP server hosting
 with stdio and HTTP+SSE managers” and positions a tool router in Corbusier’s
-call path. citeturn23view4turn23view2 Its initial lifecycle implementation
-provides an `InMemoryMcpServerHost` adapter for deterministic tests, which
-currently appears as the concrete “runtime host” adapter in the repo.
-citeturn15view4
+call path. Its initial lifecycle implementation provides an
+`InMemoryMcpServerHost` adapter for deterministic tests, which currently
+appears as the concrete “runtime host” adapter in the repo.
 
 ### Podbot contract constraints Corbusier must respect
 
@@ -67,18 +62,17 @@ Podbot’s design asserts three constraints that materially affect Corbusier
 integration:
 
 - Podbot is **both** CLI and embeddable Rust library; library functions return
-  typed results and must not write directly to stdout/stderr. citeturn28view0
+  typed results and must not write directly to stdout/stderr.
 - In hosting mode, Podbot must preserve **stdout purity**: container-protocol
-  bytes only, with diagnostics on stderr. citeturn28view0
+  bytes only, with diagnostics on stderr.
 - For ACP hosting, Podbot enforces **capability masking** by rewriting the ACP
   `initialize` exchange to remove `terminal/*` and `fs/*`, and may reject those
   calls if attempted. An explicit opt-in may allow delegation.
-  citeturn28view0
 
 On workspace strategy, Podbot’s config explicitly supports
 `workspace.source = github_clone | host_mount`, and defines hard safety
 requirements for host mounts (canonicalization, allowlisted roots, symlink
-escape rejection). citeturn28view0
+escape rejection).
 
 ### MCP hosting alignment target
 
@@ -88,7 +82,7 @@ The Podbot MCP hosting design recommends:
 - Podbot creates “wires”, performs bridging and clean-up, injects the resulting
   URL + auth material into the agent container,
 - the agent consumes **Streamable HTTP** endpoints, even when the true source
-  is stdio. citeturn25view0turn29search0turn29search7
+  is stdio.
 
 This creates a **direct mismatch** with Corbusier’s current “tool registry &
 router in the call path” mental model: if the agent container talks to MCP
@@ -99,7 +93,7 @@ integration design:
 
 - **Option A (recommended by Podbot docs):** agent container is the MCP client;
   Corbusier moves from “tool router” to “tool policy + wire provisioning +
-  audit ingestion”. citeturn25view0
+  audit ingestion”.
 - **Option B (legacy Corbusier model):** Corbusier remains the caller; Podbot
   executes tools inside container and returns results to Corbusier. This would
   require a Podbot→Corbusier tool-call bridge API that is **unspecified** in
@@ -121,7 +115,7 @@ request/response shapes, stable enums).
 
 Corbusier needs a runtime description that maps cleanly to Podbot’s
 `agent.kind`, `agent.mode`, and optional custom command fields, plus an env
-allowlist. citeturn28view0
+allowlist.
 
 ```rust
 /// Corbusier-owned description of the agent runtime to launch via Podbot.
@@ -145,17 +139,15 @@ pub enum AgentMode { Interactive, CodexAppServer, Acp }
 Conformance requirements:
 
 - `AgentMode::Acp` must assume that `terminal/*` and `fs/*` are masked by
-  Podbot and are not reliable capabilities. citeturn28view0
+  Podbot and are not reliable capabilities.
 - `env_allowlist` must be enforced in Corbusier configuration generation, not
   left as an “advisory” field (Podbot treats this as a contract boundary).
-  citeturn28view0
 
 ### WorkspaceSource
 
 Corbusier needs to decide whether Podbot clones into a container-local volume
 (`github_clone`) or bind-mounts a host workspace (`host_mount`). Podbot’s
 existing config describes both modes and imposes safety policy for host mounts.
-citeturn28view0
 
 ```rust
 #[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
@@ -176,17 +168,16 @@ pub enum WorkspaceSource {
 
 **Unspecified detail:** Corbusier’s repo currently lacks a concrete “workspace
 manager” implementation in code; the Corbusier design doc contains a conceptual
-`EncapsulationProvider` but no corresponding crate module.
-citeturn26view0turn24view0 You must create this module and decide whether
-Corbusier itself provisions the host workspace directory (recommended for
-determinism) or delegates cloning to Podbot (aligns with Podbot’s existing
-`github_clone` flow). citeturn28view0
+`EncapsulationProvider` but no corresponding crate module. Corbusier must
+create this module and decide whether it provisions the host workspace
+directory (recommended for determinism) or delegates cloning to Podbot (aligns
+with Podbot’s existing `github_clone` flow).
 
 ### McpEndpointSource
 
 Corbusier’s persistent transport model should be updated to match Podbot’s
 recommended `McpSource` shape: `Stdio`, `StdioContainer`, `StreamableHttp`,
-with explicit repo volume sharing for helper containers. citeturn25view0
+with explicit repo volume sharing for helper containers.
 
 ```rust
 #[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
@@ -215,7 +206,6 @@ pub enum RepoAccess { None, ReadOnly, ReadWrite }
 
 This aligns with Podbot’s MCP hosting design, where Podbot normalizes the
 agent-facing transport to Streamable HTTP even when the source is stdio.
-citeturn25view0turn29search0turn29search7
 
 **Required Corbusier schema change:** Corbusier’s existing
 `mcp_servers.transport` JSONB column is flexible, but the *meaning* of stored
@@ -223,7 +213,6 @@ transports must evolve: stop modelling “HTTP+SSE” as first-class, and align
 persisted transport shapes to *source definitions*
 (stdio/stdio-container/streamable-http), leaving “agent-facing URL” as a
 per-workspace wire artefact rather than a global server attribute.
-citeturn10view0turn25view0
 
 ### HookArtifact and HookSubscription
 
@@ -265,7 +254,7 @@ pub enum WorkspaceAccessMode { ReadOnly, ReadWrite }
 #[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
 pub enum HookTrigger {
     // Concrete trigger taxonomy is currently unspecified in Podbot docs;
-    // Corbusier design doc lists commit/merge/deploy style governance triggers conceptually. citeturn23view4
+    // Corbusier design doc lists commit/merge/deploy style governance triggers conceptually.
     PreTurn,
     PostTurn,
     PreToolCall,
@@ -279,17 +268,16 @@ pub enum HookTrigger {
 **Unspecified but required:** a concrete mapping between Corbusier’s workflow
 events and hook triggers (including which component emits them) is not
 implemented in Corbusier today, and Podbot has no hook spec in its current
-design docs. You must author a binding spec inside the Corbusier–Podbot
+design docs. A binding spec must be authored inside the Corbusier–Podbot
 integration layer that at minimum defines: trigger names, payload schema, ack
 semantics, timeout/resume rules, and audit persistence fields.
 
 ### Prompt validation request/response and capability dispositions
 
 Corbusier already has an agent capability model (`supports_streaming`,
-`supports_tool_calls`, supported content types). citeturn19view0turn3view3
-Podbot adds a runtime-enforced capability mask for ACP (`terminal/*`, `fs/*`).
-citeturn28view0 To unify these, introduce prompt-surface capabilities and
-dispositions.
+`supports_tool_calls`, supported content types). Podbot adds a runtime-enforced
+capability mask for ACP (`terminal/*`, `fs/*`). To unify these, introduce
+prompt-surface capabilities and dispositions.
 
 ```rust
 #[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
@@ -325,9 +313,9 @@ pub enum CapabilityDisposition {
 }
 ```
 
-This is the core of the requested “validate endpoint” behaviour: identify
-capabilities the prompt requests that a specific agent runtime will ignore (or
-reject), with explicit reasons.
+This is the core of the proposed `validate_prompt` behaviour: identify
+capabilities the prompt requests that a specific agent runtime will ignore or
+reject, with explicit reasons.
 
 ## Ports, services, and refactors
 
@@ -338,7 +326,6 @@ Corbusier.
 
 Corbusier should add three new port families. They mirror the Podbot
 recommended responsibility split (policy in Corbusier, wiring in Podbot).
-citeturn25view0
 
 #### PodbotAgentLauncher
 
@@ -368,13 +355,13 @@ pub trait PodbotAgentLauncher: Send + Sync {
 }
 ```
 
-This port must be implemented as a Podbot adapter that does not violate
-Podbot’s stdout-purity and no-direct-print requirements. citeturn28view0
+This proposed port should be implemented as a Podbot adapter that does not
+violate Podbot’s stdout-purity and no-direct-print requirements.
 
 #### WorkspaceMcpWires
 
 A Corbusier port that calls Podbot’s MCP wire surface (as proposed in Podbot’s
-MCP hosting design) and returns injection details. citeturn25view0
+MCP hosting design) and returns injection details.
 
 ```rust
 #[async_trait::async_trait]
@@ -401,14 +388,13 @@ pub trait WorkspaceMcpWires: Send + Sync {
 
 This is the key boundary where Corbusier transitions from “MCP server lifecycle
 manager” to “MCP wire provisioning manager”, matching Podbot’s design.
-citeturn25view0
 
 #### HookCoordinator, HookRegistry, HookPolicyService
 
 Corbusier needs a workflow-governance subsystem consistent with its own design
 goals (hook engine and encapsulation management appear as planned features).
-citeturn23view1turn24view0 Under the user’s hook assumptions,
-HookCoordinator must also coordinate acknowledgements to Podbot.
+Under the user’s hook assumptions, HookCoordinator must also coordinate
+acknowledgements to Podbot.
 
 ```rust
 #[async_trait::async_trait]
@@ -440,28 +426,27 @@ pub trait HookCoordinator: Send + Sync {
 ```
 
 **Unspecified detail:** the Podbot hook message schema and transport
-(“podbot→orchestrator channel”) do not exist in current Podbot docs. This must
-be implemented either as a typed callback channel in the embedding library or
-an out-of-band transport (e.g. UDS) for CLI mode. Either way, it must not
-violate Podbot hosting stdout purity. citeturn28view0
+(“podbot→orchestrator channel”) do not exist in current Podbot docs. This
+proposed integration interface must be implemented either as a typed callback
+channel in the embedding library or an out-of-band transport (e.g. UDS) for CLI
+mode. Either way, it must not violate Podbot hosting stdout purity.
 
 ### Lifecycle and service refactors
 
 #### Tool registry lifecycle split
 
 Currently, Corbusier’s `tool_registry/services` exports
-`McpServerLifecycleService` and `ToolDiscoveryRoutingService`.
-citeturn18view2 Corbusier must split “server definition lifecycle” from
-“workspace wiring lifecycle”:
+`McpServerLifecycleService` and `ToolDiscoveryRoutingService`. Corbusier must
+split “server definition lifecycle” from “workspace wiring lifecycle”:
 
 - **Keep:** `McpServerLifecycleService` as the CRUD/health layer for globally
   registered MCP server *definitions* (sources), stored in
-  `mcp_servers.transport`. citeturn10view0turn18view2
+  `mcp_servers.transport`.
 - **Add:** `WorkspaceMcpWireService` as the per-workspace provisioning layer
   that calls Podbot to create wires and persists the returned Streamable HTTP
-  endpoints by workspace. citeturn25view0turn29search0
+  endpoints by workspace.
 - **Change:** `ToolDiscoveryRoutingService` should no longer assume Corbusier
-  is the runtime invoker for containerised agents (Option A). Instead it
+  is the runtime invoker for containerized agents (Option A). Instead it
   becomes:
   - a “catalogue service” used to materialize tool lists for UI/audit, and/or
   - a “bootstrap tool manifest builder” for agents (by creating wires and
@@ -469,7 +454,7 @@ Currently, Corbusier’s `tool_registry/services` exports
 
 This refactor also aligns with Corbusier’s design doc, which already
 anticipates a workspace manager and Podbot adapter, but currently only at the
-conceptual level. citeturn26view0turn24view0
+conceptual level.
 
 #### Workspace-wire service & schema
 
@@ -478,7 +463,6 @@ Introduce new persistent entities:
 - `workspaces` (or `workspace_runtimes`) that identifies a Podbot workspace /
   volume and correlates to `task_id` and possibly `conversation_id`. (Corbusier
   already has task lifecycle and agent sessions/handoffs persistence patterns.)
-  citeturn24view0turn10view2
 - `workspace_mcp_wires` with:
   - `workspace_id`
   - `wire_name` (stable name referenced by prompts)
@@ -488,46 +472,85 @@ Introduce new persistent entities:
   - `status` and timestamps
 
 This matches Podbot’s contract: Corbusier says *what to wire*; Podbot returns
-*how the container reaches it* (URL + headers). citeturn25view0turn29search0
+*how the container reaches it* (URL + headers).
 
 #### Hook coordinator state machine
 
 Corbusier must store hook execution and acknowledgement for auditability
-(consistent with its broader audit goals in tool calls and agent handoffs).
-citeturn23view4turn10view2 A concrete minimal state machine for hook gating:
+(consistent with its broader audit goals in tool calls and agent handoffs). A
+concrete minimal state machine for hook gating:
 
 - `Pending` (hook requested by Podbot, not yet authorised)
-- `Authorised` or `Denied` (after HookPolicyService decision)
+- `Authorized` or `Denied` (after HookPolicyService decision)
 - `Acked` (ack delivered to Podbot)
-- `Completed` / `Failed` (if Podbot also emits completion events;
-  **unspecified**)
+- `Completed` / `Failed` (proposed future states if Podbot later emits
+  completion events; currently unspecified)
 
 Corbusier must guarantee idempotent ack behaviour: repeated hook request
 messages (e.g. after restart) must not cause duplicate approvals.
 
 ### Concrete Corbusier file changes mapping
 
-The following table maps existing Corbusier files (plus a few “new file”
+The following list maps existing Corbusier files (plus a few “new file”
 touchpoints) to required refactors. File existence and module layout are
 derived from the current repository tree.
-citeturn5view0turn11view0turn19view0turn22view0
 
-| File path                                               | Current responsibility                                                                                                                     | Proposed change                                                                                                                                                      | Risk / effort |
-| ------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------- |
-| `src/lib.rs`                                            | Declares top-level modules (`agent_backend`, `tool_registry`, etc.). citeturn21view0                                                    | Add new modules: `workspace` (encapsulation), `hook_engine`, `prompt`, `bundle`, `podbot_adapter`.                                                                   | Med           |
-| `src/main.rs`                                           | Stub entry point. citeturn21view1                                                                                                       | Replace with real server/daemon bootstrap only when Corbusier’s HTTP/event surfaces are delivered; not strictly required for library-integration work.               | Low           |
-| `docs/corbusier-design.md`                              | High-level architecture incl. workspace management and `EncapsulationProvider` concept. citeturn26view0turn23view4                     | Update to reflect Podbot MCP wire model (Streamable HTTP), hook ack channel, prompt validation surface, and tool router role shift (Option A).                       | Med           |
-| `docs/roadmap.md`                                       | Delivery plan; workspace encapsulation and hook engine remain planned. citeturn24view0                                                  | Add explicit milestones for Podbot wire provisioning + hook coordinator + prompt validation.                                                                         | Low           |
-| `src/tool_registry/domain/transport.rs`                 | Transport modelling for MCP server connectivity (currently includes legacy shapes such as HTTP+SSE). citeturn3view0turn23view4         | Replace/alias to `McpEndpointSource` (`Stdio`, `StdioContainer`, `StreamableHttp`) and treat Streamable HTTP as the default agent-facing injection.                  | High          |
-| `src/tool_registry/ports/host.rs`                       | Defines MCP server hosting port (start/stop/health/list_tools/call_tool). citeturn3view1turn23view4                                    | Deprecate for Podbot-hosted agents; keep only for tests/local. Introduce new ports `WorkspaceMcpWires` and (optionally) `McpCatalogReader` for registry UI.          | High          |
-| `src/tool_registry/services/lifecycle/mod.rs`           | Service orchestration for MCP server lifecycle. citeturn3view2turn18view2                                                              | Split: definition lifecycle vs workspace-wire lifecycle. Move wire operations out of “server lifecycle” into `workspace/wires.rs` service.                           | High          |
-| `src/tool_registry/services/discovery/log_and_audit.rs` | Tool discovery logging/audit capture. citeturn18view0                                                                                   | Convert to “registry audit” and “wire provisioning audit” for Option A; add ingestion hooks for Podbot-provided tool call logs if implemented (unspecified).         | Med/High      |
-| `src/tool_registry/domain/validation.rs`                | Lightweight schema validation for tool parameters. citeturn12view1                                                                      | Extend or reuse for prompt input schema validation; consider adding full JSON Schema later (explicitly assess).                                                      | Med           |
-| `src/tool_registry/adapters/runtime.rs`                 | In-memory MCP host adapter for tests. citeturn15view4                                                                                   | Keep; add Podbot-wire fakes for integration tests; do not overload this module with real Podbot wiring.                                                              | Low/Med       |
-| `migrations/..._add_mcp_servers_table/up.sql`           | Adds `mcp_servers` with `transport` JSONB. citeturn10view0                                                                              | New migrations: `workspace_runtimes`, `workspace_mcp_wires`, `hook_executions`, prompt/bundle registries if persisted.                                               | Med           |
-| `src/agent_backend/domain/capabilities.rs`              | Agent capability flags (`supports_streaming`, `supports_tool_calls`, content types). citeturn3view3turn19view0                         | Extend with `PromptSurfaceCapabilities` and ACP-related constraints; create capability-to-disposition mapping for validation.                                        | Med           |
-| `src/agent_backend/services/registry.rs`                | Backend registry and discovery. citeturn20view0turn24view0                                                                             | Add runtime-spec resolution: map backend registry entries to `AgentRuntimeSpec` and launch via Podbot when backend is “podbot-hosted”.                               | Med           |
-| `src/worker/*` and `src/bin/pg_worker.rs`               | Background work infrastructure. citeturn22view0turn5view3                                                                              | Add background sweeps: stale wire cleanup, hook timeout handling, and possibly Podbot reconcile loops.                                                               | Med           |
+- `src/lib.rs`: declares top-level modules (`agent_backend`, `tool_registry`,
+  etc.). Proposed change: add new modules `workspace` (encapsulation),
+  `hook_engine`, `prompt`, `bundle`, and `podbot_adapter`. Risk / effort: Med.
+- `src/main.rs`: stub entry point. Proposed change: replace with real
+  server/daemon bootstrap only when Corbusier’s HTTP/event surfaces are
+  delivered; not strictly required for library-integration work. Risk / effort:
+  Low.
+- `docs/corbusier-design.md`: high-level architecture including workspace
+  management and the `EncapsulationProvider` concept. Proposed change: update
+  to reflect the Podbot MCP wire model (Streamable HTTP), hook ack channel,
+  prompt validation surface, and tool-router role shift (Option A). Risk /
+  effort: Med.
+- `docs/roadmap.md`: delivery plan; workspace encapsulation and hook engine
+  remain planned. Proposed change: add explicit milestones for Podbot wire
+  provisioning, hook coordination, and prompt validation. Risk / effort: Low.
+- `src/tool_registry/domain/transport.rs`: transport modelling for MCP server
+  connectivity, including legacy shapes such as HTTP+SSE. Proposed change:
+  replace or alias to `McpEndpointSource` (`Stdio`, `StdioContainer`,
+  `StreamableHttp`) and treat Streamable HTTP as the default agent-facing
+  injection. Risk / effort: High.
+- `src/tool_registry/ports/host.rs`: defines the MCP server hosting port
+  (`start`, `stop`, `health`, `list_tools`, `call_tool`). Proposed change:
+  deprecate for Podbot-hosted agents, keep only for tests/local, and introduce
+  new ports `WorkspaceMcpWires` and optionally `McpCatalogReader` for registry
+  UI. Risk / effort: High.
+- `src/tool_registry/services/lifecycle/mod.rs`: service orchestration for MCP
+  server lifecycle. Proposed change: split definition lifecycle from
+  workspace-wire lifecycle, moving wire operations out of “server lifecycle”
+  into `workspace/wires.rs`. Risk / effort: High.
+- `src/tool_registry/services/discovery/log_and_audit.rs`: tool discovery
+  logging and audit capture. Proposed change: convert to “registry audit” and
+  “wire provisioning audit” for Option A, adding ingestion hooks for
+  Podbot-provided tool-call logs if implemented. Risk / effort: Med/High.
+- `src/tool_registry/domain/validation.rs`: lightweight schema validation for
+  tool parameters. Proposed change: extend or reuse for prompt input schema
+  validation, with an explicit later assessment of full JSON Schema. Risk /
+  effort: Med.
+- `src/tool_registry/adapters/runtime.rs`: in-memory MCP host adapter for
+  tests. Proposed change: keep it, add Podbot-wire fakes for integration tests,
+  and avoid overloading the module with real Podbot wiring. Risk / effort:
+  Low/Med.
+- `migrations/..._add_mcp_servers_table/up.sql`: adds `mcp_servers` with
+  `transport` JSONB. Proposed change: add migrations for `workspace_runtimes`,
+  `workspace_mcp_wires`, `hook_executions`, and prompt/bundle registries if
+  persistence is required. Risk / effort: Med.
+- `src/agent_backend/domain/capabilities.rs`: agent capability flags
+  (`supports_streaming`, `supports_tool_calls`, content types). Proposed
+  change: extend with `PromptSurfaceCapabilities` and ACP-related constraints,
+  plus capability-to-disposition mapping for validation. Risk / effort: Med.
+- `src/agent_backend/services/registry.rs`: backend registry and discovery.
+  Proposed change: add runtime-spec resolution that maps backend registry
+  entries to `AgentRuntimeSpec` and launches via Podbot when the backend is
+  “podbot-hosted”. Risk / effort: Med.
+- `src/worker/*` and `src/bin/pg_worker.rs`: background work infrastructure.
+  Proposed change: add background sweeps for stale wire cleanup, hook timeout
+  handling, and possibly Podbot reconcile loops. Risk / effort: Med.
 
 ## Prompt, bundles, and validation
 
@@ -535,17 +558,16 @@ This section proposes a concrete prompt/bundle system that aligns with:
 
 - Anthropic’s skill structure: “skills are folders” with a `SKILL.md`
   containing YAML frontmatter and instructions (minimum frontmatter keys:
-  `name`, `description`). citeturn31view0
+  `name`, `description`).
 - Claude Code’s use of Markdown + YAML frontmatter for other agent-facing
-  instruction artefacts (e.g. output styles). citeturn30search15
+  instruction artefacts (e.g. output styles).
 - Jinja2 template syntax for interpolation (`{{ ... }}` and `{% ... %}`), which
-  Goose-style templating uses. citeturn30search27
+  Goose-style templating uses.
 
 ### File taxonomy
 
 1. **Skill** (Anthropic-compatible): directory `skills/<skill-id>/SKILL.md` +
    optional supporting files (`scripts/*`, `references/*`, etc.).
-   citeturn31view0
 2. **Prompt** (Corbusier/Podbot-compatible): a Markdown prompt that can be run
    by an agent, with YAML frontmatter harmonized with SKILL.md.
 3. **Bundle**: a distributable package of skills + prompts + optional MCP
@@ -555,7 +577,6 @@ This section proposes a concrete prompt/bundle system that aligns with:
 limiting required frontmatter to `name` and `description`, while permitting
 additional namespaced keys under `x-corbusier`, `x-podbot`, etc. This preserves
 progressive disclosure conventions while enabling extra metadata.
-citeturn31view0turn30search3
 
 ### Harmonized frontmatter schema
 
@@ -630,7 +651,6 @@ Working directory: `{{ workspace.container_path }}`
 
 Jinja2 syntax and semantics for `{{ ... }}` substitution and `{% ... %}`
 control flow are documented in the upstream Jinja template reference.
-citeturn30search27
 
 ### Skill bundle abstraction
 
@@ -693,11 +713,11 @@ hooks:
 versus loading from a workspace filesystem is not currently defined in
 Corbusier. Given Podbot’s host-mount safety model, a practical first iteration
 is “bundle lives in repo, Corbusier parses it from the mounted workspace”, then
-move to a curated registry later. citeturn28view0turn24view0
+move to a curated registry later.
 
-### Podbot `validate_prompt` endpoint
+### Proposed Podbot `validate_prompt` surface
 
-Podbot should expose validation as:
+Podbot should eventually expose validation as:
 
 - a library function for embedders (Corbusier),
 - optionally, a CLI `podbot validate-prompt` that emits JSON for operators/CI.
@@ -705,7 +725,7 @@ Podbot should expose validation as:
 Validation must at minimum enforce the ACP masking reality: if the prompt
 requires terminal or fs ACP capabilities, validation should report them as
 **ignored** or **rejected** depending on whether the prompt marked them as
-required. citeturn28view0
+required.
 
 Sample request:
 
@@ -762,35 +782,32 @@ Sample response (capability ignored but prompt remains valid):
 1. **Workspace access and host mounts**  
    If Corbusier uses `host_mount`, it must implement Podbot’s required path
    policy (canonicalize, allowlist roots, reject symlink escapes). Enforcement
-   cannot be left solely to operators. citeturn28view0
+   cannot be left solely to operators.
 
 2. **Environment secret passthrough**  
    Corbusier must treat `env_allowlist` as a hard gate for both agent runtime
    and hooks. Podbot’s design explicitly separates “credential injection” from
-   “env allowlist” and requires secret redaction. citeturn28view0
+   “env allowlist” and requires secret redaction.
 
 3. **MCP transport framing and stdout purity**  
    For stdio MCP sources, MCP requires newline-delimited JSON-RPC messages with
-   no embedded newlines, and no non-protocol bytes on stdout.
-   citeturn29search7turn29search1 Podbot’s hosting design mirrors this
-   “protocol purity” goal for its own hosting mode.
-   citeturn28view0turn25view0 This implies:
+   no embedded newlines, and no non-protocol bytes on stdout. Podbot’s hosting
+   design mirrors this “protocol purity” goal for its own hosting mode. This
+   implies:
    - do not log structured diagnostics onto MCP stdio streams,
    - isolate tool/hook logs into stderr or structured side channels.
 
 4. **Repo access for helper containers**  
    Podbot’s MCP hosting design requires explicit `RepoAccess` for helper
    containers, defaulting to `None`, and distinguishes helper-container sharing
-   from the agent container’s own workspace mount. citeturn25view0 Corbusier
-   must surface this in policy/UI and persist it in the server definition
-   schema.
+   from the agent container’s own workspace mount. Corbusier must surface this
+   in policy/UI and persist it in the server definition schema.
 
 5. **ACP delegation**  
    Corbusier must not rely on ACP’s “IDE-host tools” for file system or
    terminal operations when using Podbot-hosted agents; Podbot masks them by
    default. Any override to allow ACP delegation is a trust-boundary change
    that Corbusier should treat as policy-controlled and auditable.
-   citeturn28view0
 
 ### Migration plan
 
@@ -802,7 +819,7 @@ registry while introducing Podbot-wired operation safely.
   with historical variants; add a compatibility layer:
   - map legacy `http_sse` records to `streamable_http` where possible
     (Streamable HTTP may optionally employ SSE for streaming, but the defining
-    contract is Streamable HTTP). citeturn29search0turn25view0  
+    contract is Streamable HTTP).  
   - keep legacy parsing to avoid migration failures, but re-serialize to the
     new source model on update.
 
@@ -810,14 +827,14 @@ registry while introducing Podbot-wired operation safely.
   If Corbusier currently expects SSE as a first-class transport, treat it as
   deprecated and only supported via bridging layers (Podbot can optionally use
   SSE within Streamable HTTP; Corbusier should not model SSE as its own stable
-  transport). citeturn29search0turn25view0 Any dedicated “SSE-only” support
-  should be explicitly labelled legacy and isolated behind an adapter boundary.
+  transport). Any dedicated “SSE-only” support should be explicitly labelled
+  legacy and isolated behind an adapter boundary.
 
 - **Staged rollout**  
   1) Ship schema + domain-type changes; keep existing lifecycle tests green
-     (using in-memory host). citeturn15view4turn10view0  
+     (using in-memory host).  
   2) Add Podbot-wire provisioning for one “golden path” MCP server and one
-     workspace strategy (likely host_mount). citeturn28view0turn25view0  
+     workspace strategy (likely host_mount).  
   3) Enable prompt/bundle parsing and validation in “warn-only” mode
      (diagnostics logged/audited but not blocking).  
   4) Enforce policy gates and hook acknowledgements in “block” mode.
@@ -825,23 +842,24 @@ registry while introducing Podbot-wired operation safely.
 ### Tests and QA requirements
 
 Corbusier already emphasises deterministic testing via in-memory adapters and
-structured audit trails. citeturn15view4turn23view4 Extend this with:
+structured audit trails. Extend this with:
 
 - **Unit tests**
   - transport conversion: legacy → new `McpEndpointSource`
   - prompt parsing + frontmatter validation
   - capability disposition mapping (ACP masked capabilities must produce
-    deterministic diagnostics) citeturn28view0
+    deterministic diagnostics)
 
 - **Integration tests**
   - `WorkspaceMcpWires` fake that simulates Podbot returning Streamable HTTP
-    endpoints and headers (URL + auth). citeturn25view0turn29search0
+    endpoints and headers (URL + auth).
   - hook coordinator idempotency: duplicate hook requests after restart must
     not double-ack.
 
 - **E2E tests (requires real Podbot + container engine)**
   - create workspace (host mount), create 2 MCP wires, launch ACP agent, ensure:
-    - terminal/fs capabilities are masked (validate_prompt warns appropriately),
+    - terminal/fs capabilities are masked (the proposed `validate_prompt`
+      surface warns appropriately),
     - hooks suspend and resume correctly across ack,
     - failure/restart scenario: Corbusier restarts mid-hook; it resumes and
       acks exactly once.
@@ -854,15 +872,18 @@ runtime mechanics:
 - Update Corbusier design doc sections describing tool hosting and workspace
   encapsulation, replacing “HTTP+SSE manager” framing with “Podbot MCP wires
   presenting Streamable HTTP to agent containers”.
-  citeturn23view4turn25view0turn29search0
 - Update Corbusier roadmap to include:
   - Podbot wire provisioning milestone (under encapsulation/workspace
     management),
   - hook coordinator + ack loop milestone (hook engine),
   - prompt validation milestone (external interface + governance).
-    citeturn24view0
 
 ### Implementation timeline
+
+The timeline below shows the recommended sequencing for the main Corbusier and
+Podbot integration workstreams.
+
+Figure: Corbusier–Podbot staged implementation timeline.
 
 ```mermaid
 gantt
@@ -884,7 +905,7 @@ Hook protocol + ack integration [H]       :c2, after c1, 15d
 
 section Prompts and bundles
 Prompt/Bundle parsing + frontmatter [M]   :d1, after a1, 15d
-Podbot validate_prompt surface [M]        :d2, after d1, 15d
+Proposed Podbot validate_prompt [M]       :d2, after d1, 15d
 Corbusier policy gating + diagnostics [M] :d3, after d2, 10d
 
 section Quality
@@ -892,12 +913,15 @@ Integration + e2e scenarios [H]           :e1, after b2, 25d
 Docs + roadmap updates [L]                :e2, after d3, 7d
 ```
 
+Legend: `[H]` high effort, `[M]` medium effort, `[L]` low effort.
+
 ### Hook protocol message flow
 
 This sequence diagram implements the required “Podbot sends hook messages;
 execution suspends until Corbusier acknowledges” assumption, without violating
 Podbot stdout purity (hook events travel over a dedicated library event
-channel, not stdout). citeturn28view0
+channel, not stdout). The post-ack `HookCompleted` / `HookSkipped` messages
+shown below are proposed future extensions rather than current Podbot contracts.
 
 ```mermaid
 sequenceDiagram
@@ -922,10 +946,10 @@ sequenceDiagram
     Note over P,A: Podbot resumes agent execution after ack
 ```
 
-**Unspecified but necessary additions:** the “HookCompleted/HookSkipped”
-messages and their payload fields are not part of current Podbot docs; include
-them only if you choose to require post-hook auditing and failure propagation
-beyond the single ack gate.
+**Unspecified but necessary additions:** the `HookCompleted` / `HookSkipped`
+messages and their payload fields are not part of current Podbot docs. Treat
+them as proposed future events for deployments that require post-hook auditing
+and failure propagation beyond the single ack gate.
 
 ______________________________________________________________________
 
@@ -935,4 +959,3 @@ policy-driven orchestrator that provisions workspaces and wires, validates
 prompts/bundles against agent runtimes, and controls governance hooks via
 explicit acknowledgements—matching the primary Podbot design intent and MCP
 transport requirements.
-citeturn25view0turn28view0turn29search0turn29search7turn31view0

--- a/docs/podbot-roadmap.md
+++ b/docs/podbot-roadmap.md
@@ -79,6 +79,8 @@ installations.
 - [ ] Add schema fields for hosting: `workspace.source`, `workspace.host_path`,
   `workspace.container_path`, `agent.command`, `agent.args`, and
   `agent.env_allowlist`.
+- [ ] Add MCP hosting defaults to configuration: bind strategy, idle timeout,
+  maximum message size, auth token policy, and allowed-origin policy.
 - [ ] Add execution-mode values required for hosting mode while preserving
   `podbot` defaults for existing configurations.
 - [ ] Define migration rules, so legacy config files load deterministically
@@ -357,9 +359,11 @@ flows.
 **Tasks:**
 
 - [ ] Define a library-level `LaunchRequest` model for agent kind, mode,
-  workspace source, and credential policy.
+  workspace source, credential policy, prompt references, bundle references,
+  skill selection, hook subscriptions, and MCP wire definitions.
 - [ ] Define a normalized `LaunchPlan` that resolves command, args, env policy,
-  mount policy, and stream policy.
+  mount policy, stream policy, artefact staging targets, and wire injection
+  details.
 - [ ] Update orchestration internals, so `run` and `host` both use the same
   normalization path.
 - [ ] Add tests that assert consistent normalization outcomes across command
@@ -368,7 +372,112 @@ flows.
 **Completion criteria:** Launch behaviour is defined once in library code and
 is consistent across CLI commands.
 
-### Step 4.6: Gated e2e orchestration suite
+### Step 4.6: Hosted session control plane
+
+Expose a typed hosted-session surface that separates protocol IO from
+control-plane events.
+
+**Tasks:**
+
+- [ ] Introduce a `HostedSession` handle that exposes protocol IO separately
+  from a typed event stream.
+- [ ] Emit typed session events for lifecycle transitions, diagnostics, MCP wire
+  status, and hook requests without writing directly to stdout or stderr.
+- [ ] Add typed control methods for session stop and hook acknowledgement.
+- [ ] Render hosted-session events to stderr in the CLI adapter while
+  preserving stdout protocol purity.
+- [ ] Add embedding-focused integration tests that drive the hosted-session
+  surface directly from library code.
+
+**Completion criteria:** Embedders can host agents through a typed session
+handle, and `podbot host` remains protocol-clean while using the same library
+surface.
+
+### Step 4.7: MCP wire provisioning and injection
+
+Provide a first-class Podbot surface for per-workspace MCP wire lifecycle.
+
+**Tasks:**
+
+- [ ] Add typed MCP wire request and response models for `Stdio`,
+  `StdioContainer`, and `StreamableHttp` sources.
+- [ ] Implement create, list, and remove operations for per-workspace MCP
+  wires, returning agent-facing URL and header injection details.
+- [ ] Keep helper-container `RepoAccess` explicit and default it to `None`.
+- [ ] Distinguish wire lifecycle from global server-definition lifecycle and
+  keep per-workspace wire state isolated from registry metadata.
+- [ ] Add integration tests covering stdio, helper-container, and remote HTTP
+  wire sources.
+
+**Completion criteria:** Podbot can provision MCP wires per workspace through a
+typed API and inject only the reachability details required by the agent.
+
+### Step 4.8: Prompt, bundle, and validation surfaces
+
+Define the artefact and validation surfaces needed for prompt-driven hosted
+sessions.
+
+**Tasks:**
+
+- [ ] Define prompt frontmatter and bundle manifest contracts that support
+  prompts, skills, MCP server references, and hook artefacts.
+- [ ] Preserve compatibility with skill-folder discovery while keeping Podbot
+  additions namespaced and reviewable.
+- [ ] Implement a library `validate_prompt` surface that returns diagnostics and
+  capability disposition results for a target agent runtime.
+- [ ] Add an optional `podbot validate-prompt` CLI that emits structured JSON
+  for operator and Continuous Integration (CI) use.
+- [ ] Add tests for prompt rendering, bundle cross-reference validation, ACP
+  capability masking diagnostics, and artefact materialization order.
+
+**Completion criteria:** Podbot can validate prompts and bundle references
+before launch with typed diagnostics, and prompt/bundle artefacts have a
+documented ingestion contract.
+
+### Step 4.9: Hook execution and orchestrator acknowledgement
+
+Implement the hosted hook protocol required for orchestrator-governed sessions.
+
+**Tasks:**
+
+- [ ] Define hook artefact and subscription models, including explicit workspace
+  access and environment allowlist policy.
+- [ ] Emit hook request events over the hosted-session event channel and suspend
+  session progress until the orchestrator acknowledges them.
+- [ ] Enforce deterministic timeout and abort semantics when acknowledgements do
+  not arrive in time.
+- [ ] Capture hook stdout and stderr into structured completion events without
+  contaminating protocol streams.
+- [ ] Add tests for acknowledgement, denial, timeout, and duplicate-delivery
+  idempotency.
+
+**Completion criteria:** Hosted sessions can gate agent progress on explicit
+hook acknowledgements through the typed session surface, with deterministic and
+test-backed semantics.
+
+### Step 4.10: Recovery, replay, and restart safety
+
+Make hosted control-plane behaviour restart-safe for wires and hook-gated
+sessions.
+
+**Tasks:**
+
+- [ ] Add monotonic event identifiers to hosted session events for ordering and
+  duplicate detection.
+- [ ] Persist minimal session state required to recover pending hooks and wire
+  lifecycle after process restart.
+- [ ] Expose a recovery API that resumes or abandons hosted sessions
+  deterministically.
+- [ ] Ensure duplicate hook requests after restart do not cause duplicate
+  acknowledgements or duplicate hook execution.
+- [ ] Add tests covering restart during pending-hook acknowledgement,
+  completion replay, and stale wire cleanup.
+
+**Completion criteria:** Podbot can recover or abandon hosted sessions
+deterministically after restart without violating stdout purity or hook
+idempotency.
+
+### Step 4.11: Gated e2e orchestration suite
 
 Create a dedicated end-to-end suite for full runtime orchestration validation.
 
@@ -397,6 +506,12 @@ Create a dedicated end-to-end suite for full runtime orchestration validation.
   mock agent shell script stub.
 - [ ] Implement e2e scenario: start Codex configured for an OpenAI-compatible
   mock inference provider implemented with Vidai Mock.
+- [ ] Implement e2e scenario: create a host-mounted workspace, provision
+  multiple MCP wires, and validate that the agent receives only injected URL
+  and header data.
+- [ ] Implement e2e scenario: trigger a hosted hook, restart the orchestrator
+  or host process mid-acknowledgement, and verify exactly-once acknowledgement
+  effects after recovery.
 - [ ] Add CI workflow wiring so the e2e suite runs in CI only when explicitly
   triggered (manual dispatch or explicit workflow call), while remaining
   available through local on-demand execution (`make test-e2e`).
@@ -461,6 +576,8 @@ Define and document the supported long-term API surface.
   `eyre` types.
 - [ ] Gate CLI-only dependencies and code paths behind a binary or feature
   boundary.
+- [ ] Reconcile the public hook and validation schemas with the documented
+  integration contract before stabilizing them.
 - [ ] Add integration tests that embed Podbot as a library from a host-style
   call path.
 
@@ -672,6 +789,26 @@ Validate protocol cleanliness across full process lifecycle transitions.
 
 **Completion criteria:** Protocol sessions remain stream-clean and framing-safe
 across startup, steady-state, and shutdown paths.
+
+### Step 8.4: Wire, hook, and validation conformance tests
+
+Validate the higher-level integration contract used by orchestrators such as
+Corbusier.
+
+**Tasks:**
+
+- [ ] Launch a host-mounted workspace with multiple MCP wires and assert the
+  returned URL and header contract is sufficient for agent startup.
+- [ ] Verify `validate_prompt` reports deterministic diagnostics for ACP-masked
+  capabilities, missing wires, and missing hooks.
+- [ ] Exercise hook acknowledgement across allow, deny, timeout, and restart
+  scenarios, asserting idempotent outcomes.
+- [ ] Assert helper-container `RepoAccess` remains explicit and never alters the
+  agent container's own workspace mount policy.
+
+**Completion criteria:** Podbot's integration contract for wires, prompt
+validation, and hook acknowledgement is validated end to end against the
+documented orchestrator-facing behaviour.
 
 ## Future enhancements
 

--- a/docs/podbot-roadmap.md
+++ b/docs/podbot-roadmap.md
@@ -518,12 +518,12 @@ Create a dedicated end-to-end suite for full runtime orchestration validation.
 - [ ] Persist e2e logs and runtime diagnostics as CI artefacts for failed and
   successful runs.
 
-**Completion criteria:** All three e2e scenarios pass reliably in the dedicated
-gated pipeline. The default test suite remains unchanged in speed and scope,
-and e2e execution occurs via local on-demand runs and explicitly triggered CI
-jobs. Preflight failures provide clear remediation guidance instead of generic
-setup errors. Parallel e2e runs do not collide, and preflight output remains
-schema-stable across surfaces.
+**Completion criteria:** All listed e2e scenarios pass reliably in the
+dedicated gated pipeline. The default test suite remains unchanged in speed and
+scope, and e2e execution occurs via local on-demand runs and explicitly
+triggered CI jobs. Preflight failures provide clear remediation guidance
+instead of generic setup errors. Parallel e2e runs do not collide, and
+preflight output remains schema-stable across surfaces.
 
 ## Phase 5: Library API and embedding support
 


### PR DESCRIPTION
## Summary
This PR updates documentation to align Corbusier integration with Podbot's MCP wiring, hosted hook protocol, and prompt validation surface. It clarifies responsibility boundaries (Corbusier policy/registry vs Podbot wiring), expands the hosted hook flow details, and broadens design guidance and roadmap accordingly.

## Changes
- ADR-003: Clarified the HookExecutionPrimitiveAndSuspendAckProtocol state machine; expanded transitions and notes for Triggered, Aborted, Executing, and Completed paths with diagrams.
- Corbusier conformance doc: Rewritten to reflect Podbot MCP wire model and Option A wiring flow; introduced integration primitives such as HookCoordinator, Prompt + skill bundle abstraction, and Podbot `validate_prompt` surface; defined new port/trait boundaries and the runtime invocation shift from Corbusier-hosted routing to Podbot-wired provisioning; added guidance on migration implications for workspace wiring and registry lifecycle.
- Podbot roadmap doc: Added milestones for MCP hosting defaults (bind strategy, idle timeout, max message size, auth token policy, allowed-origin policy) and expanded launch/normalization expectations to accommodate Podbot wires and hosted session control planes.

## Rationale
The changes ensure documentation stays in sync with the implemented MCP hosting model where Podbot owns runtime wiring and the agent container speaks HTTP-wired endpoints. This clarifies responsibility boundaries, hook governance, and prompt validation, reducing ambiguity for integrators. By formalizing HookCoordinator, prompt validation, and MCP wire provisioning in docs, the integration contract becomes explicit for testing, audits, and future work.

## Impact
- This PR updates documentation only (no code changes). It establishes a clearer integration contract and expectations for future Podbot wiring, hook flow, and prompt validation features.

## Migration / Backward Compatibility
- No code migrations are required. Documentation updates reflect current design direction and integration contract expectations.

## Testing plan
- Review changes for accuracy against current implementation and intended MCP hosting design.
- Cross-check ADR hook flow diagrams and descriptions with actual runtime behavior once hosted-hook tests are exercised.
- Validate that roadmap additions map to concrete tasks and milestones.

## Related files touched
- docs/adr-003-define-the-hook-execution-primitive-and-suspend-ack-protocol.md
- docs/corbusier-conformance-design-for-agents-mcp-wires-and-hooks.md
- docs/podbot-roadmap.md

### Notes for reviewers
- Focus on whether the new descriptions align with the implemented/modeled Podbot MCP wiring approach (Option A) and whether the proposed integration primitives (HookCoordinator, prompt validation, workspace wires) are described consistently across docs.
- Confirm terminology and boundary lines (Corbusier policy/registry vs Podbot wiring) match the envisioned architecture and future work plans.

### Task
- https://www.devboxer.com/task/096e0a2e-8470-4bee-a999-76bf764756f2

#### Updated by DevBoxer

