### PR TITLE
Hosting schema migration Step 1.4 complete

### DIFF
--- a/docs/execplans/1-2-2-eyre-report.md
+++ b/docs/execplans/1-2-2-eyre-report.md
@@ -149,6 +149,7 @@ user-visible error output or CLI behaviour changes. Mark Step 1.2 as done in
 1. Inspect the entry point and error modules, and search for unwrap/expect:
 
    <!-- markdownlint-disable-next-line MD046 -->
+
    ```shell
    rg --hidden --line-number "unwrap\(|expect\(" src
    ```
@@ -180,6 +181,7 @@ user-visible error output or CLI behaviour changes. Mark Step 1.2 as done in
 8. Run validation commands with logs (use tee + pipefail):
 
    <!-- markdownlint-disable-next-line MD046 -->
+
    ```shell
    set -o pipefail
    make all | tee /tmp/podbot-make-all.log
@@ -188,6 +190,7 @@ user-visible error output or CLI behaviour changes. Mark Step 1.2 as done in
    If documentation changed, also run:
 
    <!-- markdownlint-disable-next-line MD046 -->
+
    ```shell
    make fmt | tee /tmp/podbot-fmt.log
    MDLINT=/root/.bun/bin/markdownlint-cli2 make markdownlint | \

--- a/docs/execplans/1-4-1-hosting-schema-migration.md
+++ b/docs/execplans/1-4-1-hosting-schema-migration.md
@@ -196,10 +196,10 @@ The configuration entry points live in four places:
 - `src/config/load_options.rs` defines the library-facing loader inputs used by
   embedders and by the CLI adapter.
 
-The current CLI surface lives in `src/cli/mod.rs`. It converts CLI flags into
-`ConfigLoadOptions`, but it does not yet expose a `host` subcommand. The
-current main entry point in `src/main.rs` dispatches only `run`,
-`token-daemon`, `ps`, `stop`, and `exec`.
+The CLI surface lives in `src/cli/mod.rs`. A `Commands::Host` variant was added
+to expose the `podbot host` subcommand, converting CLI flags into
+`ConfigLoadOptions`. The main entry point in `src/main.rs` now dispatches
+`host`, `run`, `token-daemon`, `ps`, `stop`, and `exec`.
 
 The relevant existing tests are:
 

--- a/docs/execplans/1-4-1-hosting-schema-migration.md
+++ b/docs/execplans/1-4-1-hosting-schema-migration.md
@@ -77,11 +77,11 @@ documentation, and quality gates passed.
   Severity: high. Likelihood: high. Mitigation: treat the missing `host`
   subcommand as an explicit Stage B deliverable or introduce a minimal
   subcommand intent enum shared by CLI and library validation.
-- Risk: `src/config/types.rs`, `src/config/env_vars.rs`, and existing BDD
-  helpers may exceed the 400-line limit once hosting-era fields and cases are
-  added. Severity: medium. Likelihood: high. Mitigation: pre-plan extraction
-  into submodules such as `agent.rs`, `workspace.rs`, `hosting.rs`, or
-  `validation.rs`.
+- Risk: `src/config/types.rs`, `src/config/env_vars.rs`, and existing
+  behaviour-driven development (BDD) helpers may exceed the 400-line limit once
+  hosting-era fields and cases are added. Severity: medium. Likelihood: high.
+  Mitigation: pre-plan extraction into submodules such as `agent.rs`,
+  `workspace.rs`, `hosting.rs`, or `validation.rs`.
 - Risk: the schema is still fluid enough that early assumptions from Step 1.3
   or from draft docs may no longer be the right defaults. Severity: medium.
   Likelihood: high. Mitigation: record the chosen defaults explicitly in the
@@ -259,12 +259,12 @@ semantic config error. Validation should cover at least these rules:
 1. `podbot run` allows only `agent.mode = "podbot"`.
 2. `podbot host` allows only hosted modes such as `codex_app_server` and
    `acp`.
-3. `agent.kind = "custom"` requires `agent.command` and a non-empty
-   `agent.args` policy decision recorded in the design document.
+3. `agent.kind = "custom"` requires `agent.command`, while `agent.args`
+   remains optional and defaults to `[]`.
 4. Built-in agent kinds must reject stray custom-command fields if that policy
    is chosen.
-5. `workspace.source = "host_mount"` requires `workspace.host_path` and
-   `workspace.container_path`.
+5. `workspace.source = "host_mount"` requires `workspace.host_path`;
+   `workspace.container_path` defaults to `"/workspace"` when omitted.
 6. `workspace.source = "github_clone"` must preserve `workspace.base_dir`
    semantics and should reject host-mount-only fields if that policy is chosen.
 

--- a/docs/execplans/1-4-1-hosting-schema-migration.md
+++ b/docs/execplans/1-4-1-hosting-schema-migration.md
@@ -13,17 +13,18 @@ PLANS.md is not present in the repository root, so this plan stands alone.
 Podbot's current configuration model only supports the legacy interactive
 shape: `agent.mode = "podbot"` and a clone-oriented workspace rooted at
 `workspace.base_dir`. Step 1.4 extends that schema so hosted app-server
-configurations can be represented, loaded, migrated, and validated without
-breaking existing installations.
+configurations can be represented, loaded, normalized, and validated as the
+project moves from the initial interactive-only shape toward the hosted design.
 
-Success is observable in three ways. First, legacy TOML files and
-environment-variable combinations continue to load unchanged, preserving the
-current defaults for `podbot run`. Second, hosting-era configurations load
-deterministically with explicit defaults for new fields such as
+Success is observable in three ways. First, the expanded configuration schema
+loads deterministically with explicit defaults for new fields such as
 `workspace.source`, `agent.command`, `agent.args`, `agent.env_allowlist`, and
-the new MCP hosting defaults. Third, invalid combinations of subcommand,
-`agent.kind`, `agent.mode`, and `workspace.source` fail with semantic errors
-that tell the operator what is wrong and what to do next.
+the new MCP hosting defaults. Second, the current in-repo configuration
+variants continue to parse and validate according to the newly chosen schema
+rules, even if those rules differ from earlier draft assumptions. Third,
+invalid combinations of subcommand, `agent.kind`, `agent.mode`, and
+`workspace.source` fail with semantic errors that tell the operator what is
+wrong and what to do next.
 
 This plan is the draft phase only. It defines the implementation path and
 validation criteria but does not mark Step 1.4 complete. The roadmap entry in
@@ -32,8 +33,9 @@ tests, documentation, and quality gates have all passed.
 
 ## Constraints
 
-- Preserve backward compatibility for existing configuration files,
-  environment variables, and current `podbot run` behaviour.
+- Optimize for a coherent hosted-era schema rather than preserving speculative
+  pre-release compatibility guarantees. Determinism matters; frozen legacy
+  behaviour does not.
 - Keep `AppConfig` library-facing and Clap-free. CLI-specific parsing must stay
   in `src/cli/mod.rs`.
 - Keep semantic validation in library code, not spread across ad hoc CLI
@@ -81,11 +83,11 @@ tests, documentation, and quality gates have all passed.
   added. Severity: medium. Likelihood: high. Mitigation: pre-plan extraction
   into submodules such as `agent.rs`, `workspace.rs`, `hosting.rs`, or
   `validation.rs`.
-- Risk: migration defaults may accidentally change current behaviour for legacy
-  configs, especially around workspace selection or execution mode. Severity:
-  high. Likelihood: medium. Mitigation: add explicit compatibility fixtures for
-  "legacy minimal", "legacy explicit", and "hosting-era" variants before
-  changing defaults.
+- Risk: the schema is still fluid enough that early assumptions from Step 1.3
+  or from draft docs may no longer be the right defaults. Severity: medium.
+  Likelihood: high. Mitigation: record the chosen defaults explicitly in the
+  design doc and update the configuration matrix tests to match the new source
+  of truth rather than preserving earlier draft behaviour.
 - Risk: `rstest-bdd` feature files are compile-time inputs, so changed feature
   text can appear stale under incremental builds. Severity: low. Likelihood:
   medium. Mitigation: document `cargo clean -p podbot` as the recovery step if
@@ -148,6 +150,11 @@ tests, documentation, and quality gates have all passed.
   than a CLI-only concern. Rationale: the design document requires centralized
   legality checks across `run` and `host` flows, and the library should own the
   semantic rules. Date/Author: 2026-03-29 / Codex.
+- Decision: do not treat backward compatibility for unreleased configurations
+  as a hard requirement for this step. Rationale: the user explicitly clarified
+  that Podbot is still in an early build stage, so Step 1.4 should optimize for
+  a clean hosted-era schema rather than preserving every pre-release shape.
+  Date/Author: 2026-03-29 / Codex.
 
 ## Outcomes & Retrospective
 
@@ -214,18 +221,15 @@ hosting-era fields that the roadmap requires: `workspace.source`,
 exposure in a new configuration section or sub-structure consistent with the
 design, covering bind strategy, idle timeout, maximum message size, auth token
 policy, and allowed-origin policy. Expand execution-mode support so `AgentMode`
-includes `codex_app_server` and `acp` while preserving `AgentMode::Podbot` as
-the default for legacy configurations. If needed, add `AgentKind::Custom` to
+includes `codex_app_server` and `acp`, with defaults chosen for the new schema
+rather than for backward compatibility. If needed, add `AgentKind::Custom` to
 match the design examples.
 
-Stage C is to define deterministic migration and validation rules. Use the
+Stage C is to define deterministic normalization and validation rules. Use the
 post-merge phase or a dedicated validation layer owned by `crate::config` to
-normalize missing hosting-era fields into legacy-safe defaults and to reject
-illegal combinations with `ConfigError::InvalidValue` or another semantic
-config error. This stage must make the default legacy interpretation explicit:
-legacy configs without `workspace.source` behave as clone-oriented Podbot runs,
-and they do not require manual edits. Validation should cover at least these
-rules:
+normalize missing hosting-era fields into the newly chosen defaults and to
+reject illegal combinations with `ConfigError::InvalidValue` or another
+semantic config error. Validation should cover at least these rules:
 
 1. `podbot run` allows only `agent.mode = "podbot"`.
 2. `podbot host` allows only hosted modes such as `codex_app_server` and
@@ -246,15 +250,15 @@ can be passed into config validation from the existing CLI and later host
 implementation. Keep the semantic legality checks in shared code so both CLI
 and embedders receive the same rules and error messages.
 
-Stage E is to add the compatibility matrix tests. Unit coverage should use
-`rstest` fixtures and parameterized cases for legacy defaults, hosting-era
-defaults, mixed-layer overrides, invalid enum values, illegal field
-combinations, and migration behaviour. Behavioural coverage should use
+Stage E is to add the configuration matrix tests. Unit coverage should use
+`rstest` fixtures and parameterized cases for interactive-only defaults,
+hosting-era defaults, mixed-layer overrides, invalid enum values, illegal field
+combinations, and normalization behaviour. Behavioural coverage should use
 `rstest-bdd` feature scenarios covering both happy and unhappy paths, including
-at least one scenario proving that a legacy config still loads unchanged and at
-least one scenario proving that an invalid hosting combination emits an
-actionable semantic error. Prefer scenario state and injected mock environment
-patterns over live environment mutation.
+at least one scenario proving that the new interactive default path is still
+valid and at least one scenario proving that an invalid hosting combination
+emits an actionable semantic error. Prefer scenario state and injected mock
+environment patterns over live environment mutation.
 
 Stage F is to update documentation. Record the final migration rules and
 validation decisions in `docs/podbot-design.md`. Update `docs/users-guide.md`
@@ -308,13 +312,14 @@ tests and the new compatibility scenarios.
 
 4. Update defaults and loader serialization.
 
-   Ensure `AppConfig::default()` still models the legacy behaviour:
+   Ensure `AppConfig::default()` models the newly chosen default behaviour:
 
    - `agent.kind = claude`
    - `agent.mode = podbot`
-   - `workspace.source = github_clone` or the equivalent legacy-safe default
+   - `workspace.source = github_clone` or the new explicit default chosen for
+     the hosted-era schema
    - `workspace.base_dir = /work`
-   - hosting defaults present but non-breaking for legacy configs
+   - hosting defaults present and explicit
 
 5. Extend environment-variable mapping in `src/config/env_vars.rs`.
 
@@ -347,12 +352,12 @@ tests and the new compatibility scenarios.
 
    Cover:
 
-   - legacy default config
-   - legacy explicit config file
+   - interactive default config
+   - explicit interactive config file
    - hosting explicit config file
    - env/file/override precedence for hosting fields
    - invalid combination errors
-   - migration from missing `workspace.source`
+   - normalization from omitted hosting-era fields
 
 9. Add rstest-bdd behavioural coverage.
 
@@ -367,7 +372,7 @@ tests and the new compatibility scenarios.
 
    Add scenarios for:
 
-   - legacy config loads with podbot defaults
+   - interactive config loads with podbot defaults
    - hosting config loads with host-mount fields
    - invalid hosted mode under `run`
    - missing host-mount path fields
@@ -431,19 +436,19 @@ tests and the new compatibility scenarios.
 
 The implementation is acceptable only when all of the following are true:
 
-- Legacy configuration files that predate Step 1.4 still load without manual
-  edits and still resolve to Podbot's existing interactive defaults.
 - Hosting-era configuration files can express hosted agent modes, host-mounted
   workspaces, custom agent commands, environment allowlists, and MCP hosting
   defaults.
+- The chosen post-Step-1.4 defaults are deterministic and covered by both unit
+  and behavioural tests, even where they supersede earlier draft assumptions.
 - Illegal combinations of subcommand, `agent.kind`, `agent.mode`, and
   `workspace.source` fail with actionable semantic errors rather than opaque
   parse failures.
 - Unit coverage exists for happy paths, unhappy paths, and edge cases using
   `rstest`.
-- Behavioural coverage exists for happy paths, unhappy paths, and migration
-  scenarios using `rstest-bdd` v0.5.0.
-- `docs/podbot-design.md` records the migration/defaulting decisions and
+- Behavioural coverage exists for happy paths, unhappy paths, and
+  normalization/defaulting scenarios using `rstest-bdd` v0.5.0.
+- `docs/podbot-design.md` records the defaulting/normalization decisions and
   `docs/users-guide.md` reflects the user-visible behaviour.
 - `make check-fmt`, `make lint`, and `make test` pass. Because this step edits
   Markdown, `make fmt`, `make markdownlint`, and `make nixie` must also pass.
@@ -469,12 +474,12 @@ and after the split.
 
 Capture concise evidence in the implementation turn:
 
-- a passing unit test excerpt for the compatibility matrix
-- a passing BDD excerpt for one legacy and one hosting scenario
+- a passing unit test excerpt for the configuration matrix
+- a passing BDD excerpt for one interactive and one hosting scenario
 - the final `make check-fmt`, `make lint`, and `make test` success lines
 - any new semantic error strings that users will see
 
-If the implementation introduces a non-obvious migration rule or validation
+If the implementation introduces a non-obvious normalization rule or validation
 constraint, store a Qdrant project-memory note after the code lands.
 
 ## Interfaces and Dependencies

--- a/docs/execplans/1-4-1-hosting-schema-migration.md
+++ b/docs/execplans/1-4-1-hosting-schema-migration.md
@@ -104,18 +104,14 @@ documentation, and quality gates passed.
   design intent and codebase seams.
 - [x] (2026-03-29 02:00Z) Draft approved by user.
 - [x] (2026-03-29 03:00Z) Extend configuration schema and defaults for
-      hosting-era fields and MCP
-  hosting defaults.
+  hosting-era fields and MCP hosting defaults.
 - [x] (2026-03-29 03:00Z) Implement deterministic migration rules and
-      centralized semantic
-  validation.
+  centralized semantic validation.
 - [x] (2026-03-29 03:00Z) Add rstest unit coverage and rstest-bdd behavioural
-      coverage for the
-  compatibility matrix.
+  coverage for the compatibility matrix.
 - [x] (2026-03-29 03:00Z) Update design and user documentation.
 - [x] (2026-03-29 03:00Z) Mark Step 1.4 complete in `docs/podbot-roadmap.md`
-      after all validations
-  pass.
+  after all validations pass.
 - [x] (2026-03-29 03:00Z) Run and capture validation commands.
 
 ## Surprises & Discoveries

--- a/docs/execplans/1-4-1-hosting-schema-migration.md
+++ b/docs/execplans/1-4-1-hosting-schema-migration.md
@@ -4,7 +4,7 @@ This ExecPlan is a living document. The sections `Constraints`, `Tolerances`,
 `Risks`, `Progress`, `Surprises & Discoveries`, `Decision Log`, and
 `Outcomes & Retrospective` must be kept up to date as work proceeds.
 
-Status: DRAFT
+Status: COMPLETE
 
 PLANS.md is not present in the repository root, so this plan stands alone.
 
@@ -26,10 +26,9 @@ invalid combinations of subcommand, `agent.kind`, `agent.mode`, and
 `workspace.source` fail with semantic errors that tell the operator what is
 wrong and what to do next.
 
-This plan is the draft phase only. It defines the implementation path and
-validation criteria but does not mark Step 1.4 complete. The roadmap entry in
-`docs/podbot-roadmap.md` should be updated only after the implementation,
-tests, documentation, and quality gates have all passed.
+This plan now records the implemented Step 1.4 delivery. The roadmap entry in
+`docs/podbot-roadmap.md` was updated after the implementation, tests,
+documentation, and quality gates passed.
 
 ## Constraints
 
@@ -103,17 +102,21 @@ tests, documentation, and quality gates have all passed.
   config types, loader, CLI, unit tests, and BDD coverage.
 - [x] (2026-03-29 00:00Z) Collected planning input from agent team members for
   design intent and codebase seams.
-- [ ] Draft approved by user.
-- [ ] Extend configuration schema and defaults for hosting-era fields and MCP
+- [x] (2026-03-29 02:00Z) Draft approved by user.
+- [x] (2026-03-29 03:00Z) Extend configuration schema and defaults for
+      hosting-era fields and MCP
   hosting defaults.
-- [ ] Implement deterministic migration rules and centralized semantic
+- [x] (2026-03-29 03:00Z) Implement deterministic migration rules and
+      centralized semantic
   validation.
-- [ ] Add rstest unit coverage and rstest-bdd behavioural coverage for the
+- [x] (2026-03-29 03:00Z) Add rstest unit coverage and rstest-bdd behavioural
+      coverage for the
   compatibility matrix.
-- [ ] Update design and user documentation.
-- [ ] Mark Step 1.4 complete in `docs/podbot-roadmap.md` after all validations
+- [x] (2026-03-29 03:00Z) Update design and user documentation.
+- [x] (2026-03-29 03:00Z) Mark Step 1.4 complete in `docs/podbot-roadmap.md`
+      after all validations
   pass.
-- [ ] Run and capture validation commands.
+- [x] (2026-03-29 03:00Z) Run and capture validation commands.
 
 ## Surprises & Discoveries
 
@@ -135,6 +138,14 @@ tests, documentation, and quality gates have all passed.
   the user prompt but remain part of the authoritative step definition.
 - The repository already pins `rstest-bdd` and `rstest-bdd-macros` at `0.5.0`,
   so no dependency update is needed for the requested behavioural coverage.
+- Adding hosted-era fields pushed the config surface past the existing
+  `src/config/types.rs` shape, so the implementation split config into
+  `agent.rs`, `workspace.rs`, `hosting.rs`, and `validation.rs` to stay below
+  the repository's 400-line limit.
+- Command-specific legality works best as loader input rather than a pure
+  post-merge hook. The implementation added `CommandIntent` to
+  `ConfigLoadOptions` so both the CLI and library embedders can request the
+  same semantic checks.
 
 ## Decision Log
 
@@ -155,12 +166,26 @@ tests, documentation, and quality gates have all passed.
   that Podbot is still in an early build stage, so Step 1.4 should optimize for
   a clean hosted-era schema rather than preserving every pre-release shape.
   Date/Author: 2026-03-29 / Codex.
+- Decision: treat `agent.args` as optional with a deterministic default of
+  `[]`, while still requiring `agent.command` for `agent.kind = "custom"`.
+  Rationale: a launcher command is the essential invariant, but forcing at
+  least one argument would reject valid commands whose protocol mode is implied
+  by the executable itself. Date/Author: 2026-03-29 / Codex.
+- Decision: use a concrete `[mcp]` config section with
+  `bind_strategy`, `idle_timeout_secs`, `max_message_size_bytes`,
+  `auth_token_policy`, and `allowed_origin_policy`. Rationale: the roadmap
+  required explicit defaults now, and these names map directly onto the design
+  document's policy categories. Date/Author: 2026-03-29 / Codex.
 
 ## Outcomes & Retrospective
 
-No implementation has been performed yet. This draft captures the required
-scope, risks, concrete files, and acceptance criteria for Step 1.4 so the
-implementation can proceed milestone by milestone after approval.
+Step 1.4 is now implemented. The configuration model supports hosted-era agent
+and workspace fields, a concrete `[mcp]` defaults section, shared semantic
+validation through `CommandIntent`, a minimal `podbot host` scaffold, and
+compatibility coverage across unit, integration, and BDD tests. Validation
+evidence was captured with `make fmt`, `make markdownlint`, `make nixie`,
+`make check-fmt`, `make lint`, and `make test`, all of which passed on
+2026-03-29.
 
 ## Context and Orientation
 

--- a/docs/execplans/1-4-1-hosting-schema-migration.md
+++ b/docs/execplans/1-4-1-hosting-schema-migration.md
@@ -1,0 +1,508 @@
+# Step 1.4: Hosting schema migration and compatibility matrix
+
+This ExecPlan is a living document. The sections `Constraints`, `Tolerances`,
+`Risks`, `Progress`, `Surprises & Discoveries`, `Decision Log`, and
+`Outcomes & Retrospective` must be kept up to date as work proceeds.
+
+Status: DRAFT
+
+PLANS.md is not present in the repository root, so this plan stands alone.
+
+## Purpose / Big Picture
+
+Podbot's current configuration model only supports the legacy interactive
+shape: `agent.mode = "podbot"` and a clone-oriented workspace rooted at
+`workspace.base_dir`. Step 1.4 extends that schema so hosted app-server
+configurations can be represented, loaded, migrated, and validated without
+breaking existing installations.
+
+Success is observable in three ways. First, legacy TOML files and
+environment-variable combinations continue to load unchanged, preserving the
+current defaults for `podbot run`. Second, hosting-era configurations load
+deterministically with explicit defaults for new fields such as
+`workspace.source`, `agent.command`, `agent.args`, `agent.env_allowlist`, and
+the new MCP hosting defaults. Third, invalid combinations of subcommand,
+`agent.kind`, `agent.mode`, and `workspace.source` fail with semantic errors
+that tell the operator what is wrong and what to do next.
+
+This plan is the draft phase only. It defines the implementation path and
+validation criteria but does not mark Step 1.4 complete. The roadmap entry in
+`docs/podbot-roadmap.md` should be updated only after the implementation,
+tests, documentation, and quality gates have all passed.
+
+## Constraints
+
+- Preserve backward compatibility for existing configuration files,
+  environment variables, and current `podbot run` behaviour.
+- Keep `AppConfig` library-facing and Clap-free. CLI-specific parsing must stay
+  in `src/cli/mod.rs`.
+- Keep semantic validation in library code, not spread across ad hoc CLI
+  branches. The design document explicitly wants
+  `(agent.kind, agent.mode, workspace.source)` handling centralized.
+- Use `camino::Utf8PathBuf` and capabilities-oriented filesystem APIs for new
+  path-bearing configuration fields.
+- Use `rstest` for unit coverage and `rstest-bdd` v0.5.0 for behavioural
+  coverage. The repository already pins `rstest-bdd = "0.5.0"`.
+- Avoid direct process-environment mutation in tests. Continue using
+  `mockable::Env` and loader injection patterns.
+- Keep all Rust modules under the 400-line limit. Split `src/config/` further
+  if adding hosting types or validation pushes a file over the limit.
+- Use en-GB-oxendict spelling in comments and documentation.
+- Run all required quality gates before considering the feature complete:
+  `make check-fmt`, `make lint`, and `make test`. If Markdown changes are made,
+  also run `make fmt`, `make markdownlint`, and `make nixie`.
+
+## Tolerances
+
+- Scope: if the implementation requires changes outside configuration, CLI,
+  tests, and the explicitly named documentation files, stop and reassess the
+  step boundary before continuing.
+- Interface: if introducing hosted-schema validation requires a new public API
+  beyond `crate::config` and the CLI adapter scaffolding, stop and document the
+  proposed surface before proceeding.
+- Dependencies: if the feature cannot be delivered with the current dependency
+  set, stop and escalate instead of adding crates opportunistically.
+- CLI coupling: if enforcing subcommand legality requires fully implementing
+  `podbot host` in this step rather than adding minimal scaffolding or shared
+  validation inputs, stop and confirm the intended scope split with the user.
+- Validation churn: if the first two iterations of the config-validation design
+  still produce unclear or unstable error messages, stop and record the
+  competing approaches in the `Decision Log`.
+
+## Risks
+
+- Risk: the roadmap and design require validation against `podbot host`, but
+  the current CLI only exposes `run`, `token-daemon`, `ps`, `stop`, and `exec`.
+  Severity: high. Likelihood: high. Mitigation: treat the missing `host`
+  subcommand as an explicit Stage B deliverable or introduce a minimal
+  subcommand intent enum shared by CLI and library validation.
+- Risk: `src/config/types.rs`, `src/config/env_vars.rs`, and existing BDD
+  helpers may exceed the 400-line limit once hosting-era fields and cases are
+  added. Severity: medium. Likelihood: high. Mitigation: pre-plan extraction
+  into submodules such as `agent.rs`, `workspace.rs`, `hosting.rs`, or
+  `validation.rs`.
+- Risk: migration defaults may accidentally change current behaviour for legacy
+  configs, especially around workspace selection or execution mode. Severity:
+  high. Likelihood: medium. Mitigation: add explicit compatibility fixtures for
+  "legacy minimal", "legacy explicit", and "hosting-era" variants before
+  changing defaults.
+- Risk: `rstest-bdd` feature files are compile-time inputs, so changed feature
+  text can appear stale under incremental builds. Severity: low. Likelihood:
+  medium. Mitigation: document `cargo clean -p podbot` as the recovery step if
+  scenario text appears out of sync.
+- Risk: public enums expanded for hosting mode may require wildcard match arms
+  in integration tests if they become `#[non_exhaustive]` later. Severity: low.
+  Likelihood: medium. Mitigation: keep behavioural assertions resilient and
+  avoid exhaustive matching in external-style tests unless required.
+
+## Progress
+
+- [x] (2026-03-29 00:00Z) Reviewed roadmap, design, MCP hosting design, current
+  config types, loader, CLI, unit tests, and BDD coverage.
+- [x] (2026-03-29 00:00Z) Collected planning input from agent team members for
+  design intent and codebase seams.
+- [ ] Draft approved by user.
+- [ ] Extend configuration schema and defaults for hosting-era fields and MCP
+  hosting defaults.
+- [ ] Implement deterministic migration rules and centralized semantic
+  validation.
+- [ ] Add rstest unit coverage and rstest-bdd behavioural coverage for the
+  compatibility matrix.
+- [ ] Update design and user documentation.
+- [ ] Mark Step 1.4 complete in `docs/podbot-roadmap.md` after all validations
+  pass.
+- [ ] Run and capture validation commands.
+
+## Surprises & Discoveries
+
+- The current configuration surface is still the Step 1.3 shape:
+  `AgentConfig` only contains `kind` and `mode`, and `WorkspaceConfig` only
+  contains `base_dir`.
+- Semantic config validation is almost empty today. `AppConfig::post_merge(...)`
+  is still a placeholder, while only `GitHubConfig::validate()` performs
+  explicit field checks.
+- The design already defines the hosting-era schema and examples in
+  `docs/podbot-design.md`, including
+  `workspace.source = "github_clone" | "host_mount"`,
+  `agent.mode = "podbot" | "codex_app_server" | "acp"`,
+  `agent.kind = "claude" | "codex" | "custom"`, and `agent.command` /
+  `agent.args` for custom hosted agents.
+- The roadmap Step 1.4 task list includes schema fields
+  (`workspace.source`, `workspace.host_path`, `workspace.container_path`,
+  `agent.command`, `agent.args`, `agent.env_allowlist`) that were omitted from
+  the user prompt but remain part of the authoritative step definition.
+- The repository already pins `rstest-bdd` and `rstest-bdd-macros` at `0.5.0`,
+  so no dependency update is needed for the requested behavioural coverage.
+
+## Decision Log
+
+- Decision: plan Step 1.4 around the full roadmap scope, not only the subset in
+  the user prompt. Rationale: `docs/podbot-roadmap.md` is the source of truth
+  for the step, and the omitted schema fields are required to make the hosting
+  migration coherent. Date/Author: 2026-03-29 / Codex.
+- Decision: keep the plan in DRAFT state and do not mark the roadmap entry
+  complete yet. Rationale: the execplans skill requires an approval gate before
+  implementation, and the feature has not been delivered. Date/Author:
+  2026-03-29 / Codex.
+- Decision: treat subcommand legality as a first-class validation input rather
+  than a CLI-only concern. Rationale: the design document requires centralized
+  legality checks across `run` and `host` flows, and the library should own the
+  semantic rules. Date/Author: 2026-03-29 / Codex.
+
+## Outcomes & Retrospective
+
+No implementation has been performed yet. This draft captures the required
+scope, risks, concrete files, and acceptance criteria for Step 1.4 so the
+implementation can proceed milestone by milestone after approval.
+
+## Context and Orientation
+
+The configuration entry points live in four places:
+
+- `src/config/types.rs` defines `AppConfig`, `AgentConfig`, `WorkspaceConfig`,
+  and the existing enums.
+- `src/config/env_vars.rs` maps `PODBOT_*` variables into the JSON layer used
+  by `MergeComposer`.
+- `src/config/loader.rs` composes defaults, file input, environment variables,
+  and host overrides into `AppConfig`.
+- `src/config/load_options.rs` defines the library-facing loader inputs used by
+  embedders and by the CLI adapter.
+
+The current CLI surface lives in `src/cli/mod.rs`. It converts CLI flags into
+`ConfigLoadOptions`, but it does not yet expose a `host` subcommand. The
+current main entry point in `src/main.rs` dispatches only `run`,
+`token-daemon`, `ps`, `stop`, and `exec`.
+
+The relevant existing tests are:
+
+- `src/config/tests/types_tests.rs` for defaults and TOML
+  serialize/deserialize coverage.
+- `src/config/tests/validation.rs` for `GitHubConfig::validate()`.
+- `tests/load_config_integration.rs` for end-to-end loader precedence and
+  typed-environment handling.
+- `tests/bdd_config.rs` and `tests/features/configuration.feature` for config
+  BDD scenarios.
+- `tests/bdd_config_loader.rs` and `tests/features/config_loader.feature` for
+  library-facing loader behaviour.
+
+The design sources to keep open during implementation are:
+
+- `docs/podbot-roadmap.md`
+- `docs/podbot-design.md`
+- `docs/mcp-server-hosting-design.md`
+- `docs/users-guide.md`
+- `docs/ortho-config-users-guide.md`
+- `docs/rust-testing-with-rstest-fixtures.md`
+- `docs/rstest-bdd-users-guide.md`
+- `docs/reliable-testing-in-rust-via-dependency-injection.md`
+- `docs/rust-doctest-dry-guide.md`
+- `docs/complexity-antipatterns-and-refactoring-strategies.md`
+
+## Plan of Work
+
+Stage A is to freeze the semantic target. Re-read the Step 1.4 section in
+`docs/podbot-roadmap.md` together with the hosting examples and migration notes
+in `docs/podbot-design.md`. Extract the exact target schema and validation
+matrix before touching code. This stage ends when the implementation has a
+written checklist of new fields, new enum values, defaults, and illegal
+combinations.
+
+Stage B is to extend the configuration schema and loader inputs. Add the
+hosting-era fields that the roadmap requires: `workspace.source`,
+`workspace.host_path`, `workspace.container_path`, `agent.command`,
+`agent.args`, and `agent.env_allowlist`. Add the hosting defaults for MCP
+exposure in a new configuration section or sub-structure consistent with the
+design, covering bind strategy, idle timeout, maximum message size, auth token
+policy, and allowed-origin policy. Expand execution-mode support so `AgentMode`
+includes `codex_app_server` and `acp` while preserving `AgentMode::Podbot` as
+the default for legacy configurations. If needed, add `AgentKind::Custom` to
+match the design examples.
+
+Stage C is to define deterministic migration and validation rules. Use the
+post-merge phase or a dedicated validation layer owned by `crate::config` to
+normalize missing hosting-era fields into legacy-safe defaults and to reject
+illegal combinations with `ConfigError::InvalidValue` or another semantic
+config error. This stage must make the default legacy interpretation explicit:
+legacy configs without `workspace.source` behave as clone-oriented Podbot runs,
+and they do not require manual edits. Validation should cover at least these
+rules:
+
+1. `podbot run` allows only `agent.mode = "podbot"`.
+2. `podbot host` allows only hosted modes such as `codex_app_server` and
+   `acp`.
+3. `agent.kind = "custom"` requires `agent.command` and a non-empty
+   `agent.args` policy decision recorded in the design document.
+4. Built-in agent kinds must reject stray custom-command fields if that policy
+   is chosen.
+5. `workspace.source = "host_mount"` requires `workspace.host_path` and
+   `workspace.container_path`.
+6. `workspace.source = "github_clone"` must preserve `workspace.base_dir`
+   semantics and should reject host-mount-only fields if that policy is chosen.
+
+Stage D is to connect validation to the CLI and library entry points. Because
+the current CLI lacks `podbot host`, decide whether this step introduces a
+minimal `host` subcommand scaffold now or a shared subcommand-intent type that
+can be passed into config validation from the existing CLI and later host
+implementation. Keep the semantic legality checks in shared code so both CLI
+and embedders receive the same rules and error messages.
+
+Stage E is to add the compatibility matrix tests. Unit coverage should use
+`rstest` fixtures and parameterized cases for legacy defaults, hosting-era
+defaults, mixed-layer overrides, invalid enum values, illegal field
+combinations, and migration behaviour. Behavioural coverage should use
+`rstest-bdd` feature scenarios covering both happy and unhappy paths, including
+at least one scenario proving that a legacy config still loads unchanged and at
+least one scenario proving that an invalid hosting combination emits an
+actionable semantic error. Prefer scenario state and injected mock environment
+patterns over live environment mutation.
+
+Stage F is to update documentation. Record the final migration rules and
+validation decisions in `docs/podbot-design.md`. Update `docs/users-guide.md`
+to document new configuration keys, environment variables, and the user-visible
+difference between `run` and `host` modes once the validation behaviour is in
+place. If the MCP hosting defaults become concrete enough to matter to
+operators, update `docs/mcp-server-hosting-design.md` as well. Only after the
+feature is implemented and validated should `docs/podbot-roadmap.md` mark Step
+1.4 as done.
+
+Stage G is validation and evidence capture. Run the required Rust quality gates
+with `tee` and `set -o pipefail`, then run the documentation gates because this
+step necessarily changes Markdown. Capture short transcripts showing passing
+tests and the new compatibility scenarios.
+
+## Concrete Steps
+
+1. Record the target schema in working notes before editing code.
+
+   Confirm the design examples and migration bullets in:
+
+   ```markdown
+   docs/podbot-roadmap.md
+   docs/podbot-design.md
+   docs/mcp-server-hosting-design.md
+   ```
+
+2. Refactor `src/config/types.rs` if needed before adding new fields.
+
+   Likely extractions:
+
+   - `src/config/agent.rs` for `AgentKind`, `AgentMode`, and `AgentConfig`
+   - `src/config/workspace.rs` for `WorkspaceConfig` and `WorkspaceSource`
+   - `src/config/hosting.rs` for MCP hosting defaults
+   - `src/config/validation.rs` for semantic normalization and legality checks
+
+3. Extend configuration enums and structs.
+
+   Minimum target additions:
+
+   - `AgentMode::{Podbot, CodexAppServer, Acp}`
+   - `AgentKind::Custom` if aligned with the design
+   - `AgentConfig.command: Option<String>`
+   - `AgentConfig.args: Vec<String>`
+   - `AgentConfig.env_allowlist: Vec<String>`
+   - `WorkspaceSource::{GithubClone, HostMount}`
+   - `WorkspaceConfig.source`
+   - `WorkspaceConfig.host_path: Option<Utf8PathBuf>`
+   - `WorkspaceConfig.container_path: Option<Utf8PathBuf>`
+   - MCP hosting defaults structure on `AppConfig`
+
+4. Update defaults and loader serialization.
+
+   Ensure `AppConfig::default()` still models the legacy behaviour:
+
+   - `agent.kind = claude`
+   - `agent.mode = podbot`
+   - `workspace.source = github_clone` or the equivalent legacy-safe default
+   - `workspace.base_dir = /work`
+   - hosting defaults present but non-breaking for legacy configs
+
+5. Extend environment-variable mapping in `src/config/env_vars.rs`.
+
+   Add every new `PODBOT_*` variable required for the hosting schema, update
+   `env_var_names()`, and keep path-conflict validation intact.
+
+6. Extend library-facing overrides and/or validation inputs if needed.
+
+   If subcommand legality needs explicit intent, introduce a shared type such
+   as `CommandIntent` or a config-validation request model rather than hiding
+   the rule inside `main.rs`.
+
+7. Implement normalization and validation.
+
+   Prefer one entry point that can be reused by both CLI and library callers.
+   The validation layer should emit actionable messages such as:
+
+   - hosted modes require `podbot host`
+   - `workspace.source = "host_mount"` requires both mount paths
+   - `agent.kind = "custom"` requires `agent.command`
+
+8. Add rstest unit coverage.
+
+   Update or add tests in:
+
+   - `src/config/tests/types_tests.rs`
+   - `src/config/tests/validation.rs`
+   - `src/config/tests/layer_precedence_tests.rs`
+   - `tests/load_config_integration.rs`
+
+   Cover:
+
+   - legacy default config
+   - legacy explicit config file
+   - hosting explicit config file
+   - env/file/override precedence for hosting fields
+   - invalid combination errors
+   - migration from missing `workspace.source`
+
+9. Add rstest-bdd behavioural coverage.
+
+   Update:
+
+   - `tests/features/configuration.feature`
+   - `tests/features/config_loader.feature`
+   - `tests/bdd_config.rs`
+   - `tests/bdd_config_helpers.rs`
+   - `tests/bdd_config_loader.rs`
+   - `tests/bdd_config_loader_helpers.rs`
+
+   Add scenarios for:
+
+   - legacy config loads with podbot defaults
+   - hosting config loads with host-mount fields
+   - invalid hosted mode under `run`
+   - missing host-mount path fields
+   - custom agent without command
+
+10. Update documentation.
+
+    Required files:
+
+    - `docs/podbot-design.md`
+    - `docs/users-guide.md`
+
+    Conditional file:
+
+    - `docs/mcp-server-hosting-design.md`
+
+    Deferred until implementation passes:
+
+    - `docs/podbot-roadmap.md`
+
+11. Run validation with logs.
+
+    Use sequential execution for Markdown tooling so formatters do not race the
+    linter:
+
+    ```shell
+    set -o pipefail
+    make fmt 2>&1 | tee /tmp/podbot-fmt.log
+    ```
+
+    ```shell
+    set -o pipefail
+    MDLINT=/root/.bun/bin/markdownlint-cli2 make markdownlint 2>&1 | \
+      tee /tmp/podbot-markdownlint.log
+    ```
+
+    ```shell
+    set -o pipefail
+    make nixie 2>&1 | tee /tmp/podbot-nixie.log
+    ```
+
+    ```shell
+    set -o pipefail
+    make check-fmt 2>&1 | tee /tmp/podbot-check-fmt.log
+    ```
+
+    ```shell
+    set -o pipefail
+    make lint 2>&1 | tee /tmp/podbot-lint.log
+    ```
+
+    ```shell
+    set -o pipefail
+    make test 2>&1 | tee /tmp/podbot-test.log
+    ```
+
+12. Mark the roadmap entry complete only after the implementation is finished
+    and all commands above pass.
+
+## Validation and Acceptance
+
+The implementation is acceptable only when all of the following are true:
+
+- Legacy configuration files that predate Step 1.4 still load without manual
+  edits and still resolve to Podbot's existing interactive defaults.
+- Hosting-era configuration files can express hosted agent modes, host-mounted
+  workspaces, custom agent commands, environment allowlists, and MCP hosting
+  defaults.
+- Illegal combinations of subcommand, `agent.kind`, `agent.mode`, and
+  `workspace.source` fail with actionable semantic errors rather than opaque
+  parse failures.
+- Unit coverage exists for happy paths, unhappy paths, and edge cases using
+  `rstest`.
+- Behavioural coverage exists for happy paths, unhappy paths, and migration
+  scenarios using `rstest-bdd` v0.5.0.
+- `docs/podbot-design.md` records the migration/defaulting decisions and
+  `docs/users-guide.md` reflects the user-visible behaviour.
+- `make check-fmt`, `make lint`, and `make test` pass. Because this step edits
+  Markdown, `make fmt`, `make markdownlint`, and `make nixie` must also pass.
+
+## Idempotence and Recovery
+
+All implementation steps should be repeatable. Configuration tests should
+continue using injected environment values so repeated runs do not depend on or
+damage global process state. If a behavioural feature file change appears not
+to take effect, run:
+
+```shell
+cargo clean -p podbot
+```
+
+Then rerun the relevant `cargo test` or `make test` command.
+
+If refactoring is required to stay under the 400-line file limit, do it as part
+of the same feature branch while preserving behaviour with passing tests before
+and after the split.
+
+## Artefacts and Notes
+
+Capture concise evidence in the implementation turn:
+
+- a passing unit test excerpt for the compatibility matrix
+- a passing BDD excerpt for one legacy and one hosting scenario
+- the final `make check-fmt`, `make lint`, and `make test` success lines
+- any new semantic error strings that users will see
+
+If the implementation introduces a non-obvious migration rule or validation
+constraint, store a Qdrant project-memory note after the code lands.
+
+## Interfaces and Dependencies
+
+Expected primary edit set:
+
+- `src/config/mod.rs`
+- `src/config/types.rs` or new `src/config/*.rs` submodules
+- `src/config/env_vars.rs`
+- `src/config/load_options.rs`
+- `src/config/loader.rs`
+- `src/cli/mod.rs`
+- `src/main.rs`
+- `src/error.rs` if new semantic config errors are needed
+- `src/config/tests/*.rs`
+- `tests/load_config_integration.rs`
+- `tests/bdd_config*.rs`
+- `tests/features/configuration.feature`
+- `tests/features/config_loader.feature`
+- `docs/podbot-design.md`
+- `docs/users-guide.md`
+- `docs/podbot-roadmap.md` after completion
+
+No new dependencies are expected. The implementation should rely on the
+existing `ortho_config`, `mockable`, `rstest`, and `rstest-bdd` stack.
+
+## Revision Note
+
+Initial draft created on 2026-03-29 from the roadmap, design documents, code
+inspection, and agent-team reconnaissance. This draft awaits user approval
+before implementation begins.

--- a/docs/podbot-design.md
+++ b/docs/podbot-design.md
@@ -544,7 +544,7 @@ Custom mode uses `agent.command` and `agent.args` so new hosted agents can be
 introduced without Rust refactors. Podbot now treats `agent.args` as optional
 with a default of `[]`, but it requires a non-empty `agent.command` whenever
 `agent.kind = "custom"`. Built-in agent kinds reject stray custom launcher
-fields so the effective runtime stays unambiguous. The configuration validator
+fields, so the effective runtime stays unambiguous. The configuration validator
 must enforce legal `(kind, mode)` combinations.
 
 The `workspace.source` setting controls where the agent sees source code:

--- a/docs/podbot-design.md
+++ b/docs/podbot-design.md
@@ -522,8 +522,15 @@ mount_dev_fuse = true
 kind = "codex"
 mode = "codex_app_server" # "podbot", "codex_app_server", or "acp"
 command = "opencode" # required when kind = "custom"
-args = ["acp"] # required when kind = "custom"
+args = ["acp"] # defaults to [] when omitted
 env_allowlist = ["ANTHROPIC_API_KEY", "OPENAI_API_KEY", "FACTORY_API_KEY"]
+
+[mcp]
+bind_strategy = "host_gateway" # "host_gateway" or "loopback"
+idle_timeout_secs = 900
+max_message_size_bytes = 1048576
+auth_token_policy = "per_workspace" # "per_workspace" or "per_wire"
+allowed_origin_policy = "same_origin" # "same_origin" or "any"
 ```
 
 The `agent.mode` setting defines the execution mode for the agent:
@@ -534,8 +541,11 @@ The `agent.mode` setting defines the execution mode for the agent:
 
 The `agent.kind` setting supports built-ins (`claude`, `codex`) and `custom`.
 Custom mode uses `agent.command` and `agent.args` so new hosted agents can be
-introduced without Rust refactors. The configuration validator must enforce
-legal `(kind, mode)` combinations.
+introduced without Rust refactors. Podbot now treats `agent.args` as optional
+with a default of `[]`, but it requires a non-empty `agent.command` whenever
+`agent.kind = "custom"`. Built-in agent kinds reject stray custom launcher
+fields so the effective runtime stays unambiguous. The configuration validator
+must enforce legal `(kind, mode)` combinations.
 
 The `workspace.source` setting controls where the agent sees source code:
 
@@ -543,6 +553,9 @@ The `workspace.source` setting controls where the agent sees source code:
 - `host_mount`: Podbot bind-mounts `workspace.host_path` at
   `workspace.container_path`, and the mounted host workspace becomes the active
   working directory for the agent.
+
+When `workspace.source = "host_mount"` and `workspace.container_path` is
+omitted, Podbot normalizes it to `"/workspace"`.
 
 In `host_mount` mode, GitHub token and clone operations are optional and should
 run only when explicitly requested.

--- a/docs/podbot-design.md
+++ b/docs/podbot-design.md
@@ -525,7 +525,7 @@ command = "opencode" # required when kind = "custom"
 args = ["acp"] # defaults to [] when omitted
 env_allowlist = ["ANTHROPIC_API_KEY", "OPENAI_API_KEY", "FACTORY_API_KEY"]
 
-[mcp]
+[mcp] # Model Context Protocol (MCP)
 bind_strategy = "host_gateway" # "host_gateway" or "loopback"
 idle_timeout_secs = 900
 max_message_size_bytes = 1048576

--- a/docs/podbot-roadmap.md
+++ b/docs/podbot-roadmap.md
@@ -76,22 +76,22 @@ installations.
 
 **Tasks:**
 
-- [ ] Add schema fields for hosting: `workspace.source`, `workspace.host_path`,
+- [x] Add schema fields for hosting: `workspace.source`, `workspace.host_path`,
   `workspace.container_path`, `agent.command`, `agent.args`, and
   `agent.env_allowlist`.
-- [ ] Add MCP hosting defaults to configuration: bind strategy, idle timeout,
+- [x] Add MCP hosting defaults to configuration: bind strategy, idle timeout,
   maximum message size, auth token policy, and allowed-origin policy.
-- [ ] Add execution-mode values required for hosting mode while preserving
+- [x] Add execution-mode values required for hosting mode while preserving
   `podbot` defaults for existing configurations.
-- [ ] Define migration rules, so legacy config files load deterministically
+- [x] Define migration rules, so legacy config files load deterministically
   without manual edits.
-- [ ] Implement validation for legal combinations of subcommand, `agent.kind`,
+- [x] Implement validation for legal combinations of subcommand, `agent.kind`,
   `agent.mode`, and `workspace.source`.
-- [ ] Add a compatibility test matrix covering legacy and hosting-era
+- [x] Add a compatibility test matrix covering legacy and hosting-era
   configuration variants.
 
 **Completion criteria:** Legacy configurations continue to load as expected,
-and hosting-mode configurations validate with actionable semantic errors.
+and hosting-mode configurations validate with actionable semantic errors. ✓
 
 ## Phase 2: Container engine integration
 

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -53,6 +53,14 @@ podbot run --repo owner/name --branch main --agent claude
 Host an app-server protocol for a long-lived agent runtime.
 
 ```bash
+podbot host --agent codex --agent-mode codex_app_server
+```
+
+For custom agents, you must configure `agent.command` via config file or
+environment variable:
+
+```bash
+export PODBOT_AGENT_COMMAND=/usr/local/bin/my-agent
 podbot host --agent custom --agent-mode acp
 ```
 

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -41,12 +41,25 @@ Run an AI agent in a sandboxed container.
 podbot run --repo owner/name --branch main --agent claude
 ```
 
-| Option         | Required | Default  | Description                        |
-| -------------- | -------- | -------- | ---------------------------------- |
-| `--repo`       | Yes      | -        | Repository in owner/name format    |
-| `--branch`     | Yes      | -        | Branch to check out                |
-| `--agent`      | No       | `claude` | Agent type: `claude` or `codex`    |
-| `--agent-mode` | No       | `podbot` | Agent execution mode (podbot only) |
+| Option         | Required | Default         | Description                                          |
+| -------------- | -------- | --------------- | ---------------------------------------------------- |
+| `--repo`       | Yes      | -               | Repository in owner/name format                      |
+| `--branch`     | Yes      | -               | Branch to check out                                  |
+| `--agent`      | No       | Config/defaults | Agent type: `claude`, `codex`, or `custom`           |
+| `--agent-mode` | No       | Config/defaults | Agent mode; `run` accepts only `podbot` semantically |
+
+#### `host`
+
+Host an app-server protocol for a long-lived agent runtime.
+
+```bash
+podbot host --agent custom --agent-mode acp
+```
+
+| Option         | Required | Default         | Description                                |
+| -------------- | -------- | --------------- | ------------------------------------------ |
+| `--agent`      | No       | Config/defaults | Agent type: `claude`, `codex`, or `custom` |
+| `--agent-mode` | No       | Config/defaults | Hosted mode: `codex_app_server` or `acp`   |
 
 #### `token-daemon`
 
@@ -175,20 +188,54 @@ mount_dev_fuse = true
 selinux_label_mode = "disable_for_container"
 
 [agent]
-# Default agent type: "claude" or "codex"
+# Default agent type: "claude", "codex", or "custom"
 kind = "claude"
-# Execution mode for the agent (currently only "podbot")
+# Execution mode for the agent: "podbot", "codex_app_server", or "acp"
 mode = "podbot"
+# Custom launcher command (required when kind = "custom")
+command = "opencode"
+# Additional launcher arguments (defaults to [])
+args = ["acp"]
+# Environment variables copied from the host (defaults to [])
+env_allowlist = ["OPENAI_API_KEY", "ANTHROPIC_API_KEY"]
 
 [workspace]
+# Workspace source: "github_clone" or "host_mount"
+source = "github_clone"
 # Base directory for cloned repositories inside the container
 base_dir = "/work"
+# Host path mounted into the sandbox when source = "host_mount"
+host_path = "/abs/path/to/project"
+# Container path for the mount; defaults to "/workspace" in host_mount mode
+container_path = "/workspace/project"
 
 [creds]
 # Copy credentials from the host into the container
 copy_claude = true
 copy_codex = true
+
+[mcp]
+# HTTP bridge reachability strategy for hosted MCP servers
+bind_strategy = "host_gateway"
+# Idle timeout in seconds for hosted MCP bridges
+idle_timeout_secs = 900
+# Maximum message size in bytes
+max_message_size_bytes = 1048576
+# Token issuance policy: "per_workspace" or "per_wire"
+auth_token_policy = "per_workspace"
+# Allowed-origin policy: "same_origin" or "any"
+allowed_origin_policy = "same_origin"
 ```
+
+Semantic validation rules:
+
+- `podbot run` accepts only `agent.mode = "podbot"`.
+- `podbot host` accepts only `agent.mode = "codex_app_server"` or `"acp"`.
+- `agent.kind = "custom"` requires a non-empty `agent.command`.
+- Built-in agent kinds reject `agent.command` and `agent.args`.
+- `workspace.source = "host_mount"` requires `workspace.host_path` and
+  defaults `workspace.container_path` to `"/workspace"` when omitted.
+- `workspace.source = "github_clone"` rejects host-mount-only fields.
 
 ### Private key file requirements
 
@@ -234,9 +281,22 @@ All configuration options can be set via environment variables using the
 | `PODBOT_SANDBOX_SELINUX_LABEL_MODE` | `sandbox.selinux_label_mode` |
 | `PODBOT_AGENT_KIND`                 | `agent.kind`                 |
 | `PODBOT_AGENT_MODE`                 | `agent.mode`                 |
+| `PODBOT_AGENT_COMMAND`              | `agent.command`              |
+| `PODBOT_AGENT_ARGS`                 | `agent.args`                 |
+| `PODBOT_AGENT_ENV_ALLOWLIST`        | `agent.env_allowlist`        |
+| `PODBOT_WORKSPACE_SOURCE`           | `workspace.source`           |
 | `PODBOT_WORKSPACE_BASE_DIR`         | `workspace.base_dir`         |
+| `PODBOT_WORKSPACE_HOST_PATH`        | `workspace.host_path`        |
+| `PODBOT_WORKSPACE_CONTAINER_PATH`   | `workspace.container_path`   |
 | `PODBOT_CREDS_COPY_CLAUDE`          | `creds.copy_claude`          |
 | `PODBOT_CREDS_COPY_CODEX`           | `creds.copy_codex`           |
+| `PODBOT_MCP_BIND_STRATEGY`          | `mcp.bind_strategy`          |
+| `PODBOT_MCP_IDLE_TIMEOUT_SECS`      | `mcp.idle_timeout_secs`      |
+| `PODBOT_MCP_MAX_MESSAGE_SIZE_BYTES` | `mcp.max_message_size_bytes` |
+| `PODBOT_MCP_AUTH_TOKEN_POLICY`      | `mcp.auth_token_policy`      |
+| `PODBOT_MCP_ALLOWED_ORIGIN_POLICY`  | `mcp.allowed_origin_policy`  |
+
+`PODBOT_AGENT_ARGS` and `PODBOT_AGENT_ENV_ALLOWLIST` use comma-separated values.
 
 ### Container engine socket
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -7,7 +7,7 @@
 use camino::Utf8PathBuf;
 use clap::{Parser, Subcommand, ValueEnum};
 
-use crate::config::{AgentKind, AgentMode, ConfigLoadOptions, ConfigOverrides};
+use crate::config::{AgentKind, AgentMode, CommandIntent, ConfigLoadOptions, ConfigOverrides};
 
 /// CLI-facing agent kind values.
 ///
@@ -21,6 +21,8 @@ pub enum AgentKindArg {
     Claude,
     /// `OpenAI` Codex agent.
     Codex,
+    /// Custom operator-supplied agent launcher.
+    Custom,
 }
 
 impl From<AgentKindArg> for AgentKind {
@@ -28,6 +30,7 @@ impl From<AgentKindArg> for AgentKind {
         match value {
             AgentKindArg::Claude => Self::Claude,
             AgentKindArg::Codex => Self::Codex,
+            AgentKindArg::Custom => Self::Custom,
         }
     }
 }
@@ -39,12 +42,18 @@ pub enum AgentModeArg {
     /// Run the agent in podbot-managed mode.
     #[default]
     Podbot,
+    /// Run the agent as a Codex App Server.
+    CodexAppServer,
+    /// Run the agent as an ACP server.
+    Acp,
 }
 
 impl From<AgentModeArg> for AgentMode {
     fn from(value: AgentModeArg) -> Self {
         match value {
             AgentModeArg::Podbot => Self::Podbot,
+            AgentModeArg::CodexAppServer => Self::CodexAppServer,
+            AgentModeArg::Acp => Self::Acp,
         }
     }
 }
@@ -93,13 +102,32 @@ impl Cli {
     /// Convert parsed CLI flags into library load options.
     #[must_use]
     pub fn config_load_options(&self) -> ConfigLoadOptions {
+        let (command_intent, agent_kind, agent_mode) = match &self.command {
+            Commands::Run(args) => (
+                CommandIntent::Run,
+                args.agent.map(Into::into),
+                args.mode.map(Into::into),
+            ),
+            Commands::Host(args) => (
+                CommandIntent::Host,
+                args.agent.map(Into::into),
+                args.mode.map(Into::into),
+            ),
+            Commands::TokenDaemon(_) | Commands::Ps | Commands::Stop(_) | Commands::Exec(_) => {
+                (CommandIntent::Any, None, None)
+            }
+        };
+
         ConfigLoadOptions {
             config_path_hint: self.config.clone(),
             discover_config: true,
             overrides: ConfigOverrides {
                 engine_socket: self.engine_socket.clone(),
                 image: self.image.clone(),
+                agent_kind,
+                agent_mode,
             },
+            command_intent,
         }
     }
 }
@@ -109,6 +137,9 @@ impl Cli {
 pub enum Commands {
     /// Run an AI agent in a sandboxed container.
     Run(RunArgs),
+
+    /// Host an app-server style agent protocol.
+    Host(HostArgs),
 
     /// Run the token refresh daemon.
     TokenDaemon(TokenDaemonArgs),
@@ -135,12 +166,24 @@ pub struct RunArgs {
     pub branch: String,
 
     /// Agent type to run.
-    #[arg(long, value_enum, default_value_t = AgentKindArg::Claude)]
-    pub agent: AgentKindArg,
+    #[arg(long, value_enum)]
+    pub agent: Option<AgentKindArg>,
 
     /// Agent execution mode.
-    #[arg(long = "agent-mode", value_enum, default_value_t = AgentModeArg::Podbot)]
-    pub mode: AgentModeArg,
+    #[arg(long = "agent-mode", value_enum)]
+    pub mode: Option<AgentModeArg>,
+}
+
+/// Arguments for the `host` subcommand.
+#[derive(Debug, Parser)]
+pub struct HostArgs {
+    /// Agent type to host.
+    #[arg(long, value_enum)]
+    pub agent: Option<AgentKindArg>,
+
+    /// Hosted execution mode.
+    #[arg(long = "agent-mode", value_enum)]
+    pub mode: Option<AgentModeArg>,
 }
 
 /// Arguments for the `token-daemon` subcommand.

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -37,7 +37,7 @@ impl From<AgentKindArg> for AgentKind {
 
 /// CLI-facing agent execution mode values.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, ValueEnum)]
-#[value(rename_all = "lowercase")]
+#[value(rename_all = "snake_case")]
 pub enum AgentModeArg {
     /// Run the agent in podbot-managed mode.
     #[default]

--- a/src/cli/tests.rs
+++ b/src/cli/tests.rs
@@ -3,8 +3,8 @@
 use camino::Utf8PathBuf;
 use rstest::rstest;
 
-use super::{AgentKindArg, AgentModeArg, Cli, Commands};
-use crate::config::{AgentKind, AgentMode, ConfigOverrides};
+use super::{AgentKindArg, AgentModeArg, Cli, Commands, HostArgs};
+use crate::config::{AgentKind, AgentMode, CommandIntent, ConfigOverrides};
 
 #[rstest]
 fn cli_config_load_options_preserves_global_flags() {
@@ -26,13 +26,17 @@ fn cli_config_load_options_preserves_global_flags() {
         ConfigOverrides {
             engine_socket: Some(String::from("unix:///example.sock")),
             image: Some(String::from("example-image:latest")),
+            agent_kind: None,
+            agent_mode: None,
         }
     );
+    assert_eq!(options.command_intent, CommandIntent::Any);
 }
 
 #[rstest]
 #[case(AgentKindArg::Claude, AgentKind::Claude)]
 #[case(AgentKindArg::Codex, AgentKind::Codex)]
+#[case(AgentKindArg::Custom, AgentKind::Custom)]
 fn agent_kind_arg_converts_to_library_kind(#[case] arg: AgentKindArg, #[case] expected: AgentKind) {
     let converted: AgentKind = arg.into();
     assert_eq!(converted, expected);
@@ -40,7 +44,49 @@ fn agent_kind_arg_converts_to_library_kind(#[case] arg: AgentKindArg, #[case] ex
 
 #[rstest]
 #[case(AgentModeArg::Podbot, AgentMode::Podbot)]
+#[case(AgentModeArg::CodexAppServer, AgentMode::CodexAppServer)]
+#[case(AgentModeArg::Acp, AgentMode::Acp)]
 fn agent_mode_arg_converts_to_library_mode(#[case] arg: AgentModeArg, #[case] expected: AgentMode) {
     let converted: AgentMode = arg.into();
     assert_eq!(converted, expected);
+}
+
+#[rstest]
+fn run_config_load_options_include_command_intent_and_agent_overrides() {
+    let cli = Cli {
+        command: Commands::Run(super::RunArgs {
+            repo: String::from("owner/name"),
+            branch: String::from("main"),
+            agent: Some(AgentKindArg::Codex),
+            mode: Some(AgentModeArg::Podbot),
+        }),
+        config: None,
+        engine_socket: None,
+        image: None,
+    };
+
+    let options = cli.config_load_options();
+
+    assert_eq!(options.command_intent, CommandIntent::Run);
+    assert_eq!(options.overrides.agent_kind, Some(AgentKind::Codex));
+    assert_eq!(options.overrides.agent_mode, Some(AgentMode::Podbot));
+}
+
+#[rstest]
+fn host_config_load_options_include_host_intent() {
+    let cli = Cli {
+        command: Commands::Host(HostArgs {
+            agent: Some(AgentKindArg::Custom),
+            mode: Some(AgentModeArg::Acp),
+        }),
+        config: None,
+        engine_socket: None,
+        image: None,
+    };
+
+    let options = cli.config_load_options();
+
+    assert_eq!(options.command_intent, CommandIntent::Host);
+    assert_eq!(options.overrides.agent_kind, Some(AgentKind::Custom));
+    assert_eq!(options.overrides.agent_mode, Some(AgentMode::Acp));
 }

--- a/src/cli/tests.rs
+++ b/src/cli/tests.rs
@@ -1,6 +1,7 @@
 //! Unit tests for the CLI adapter types.
 
 use camino::Utf8PathBuf;
+use clap::Parser;
 use rstest::rstest;
 
 use super::{AgentKindArg, AgentModeArg, Cli, Commands, HostArgs};
@@ -73,6 +74,27 @@ fn run_config_load_options_include_command_intent_and_agent_overrides() {
 }
 
 #[rstest]
+fn run_config_load_options_leave_agent_overrides_unset_when_flags_are_omitted() {
+    let cli = Cli {
+        command: Commands::Run(super::RunArgs {
+            repo: String::from("owner/name"),
+            branch: String::from("main"),
+            agent: None,
+            mode: None,
+        }),
+        config: None,
+        engine_socket: None,
+        image: None,
+    };
+
+    let options = cli.config_load_options();
+
+    assert_eq!(options.command_intent, CommandIntent::Run);
+    assert!(options.overrides.agent_kind.is_none());
+    assert!(options.overrides.agent_mode.is_none());
+}
+
+#[rstest]
 fn host_config_load_options_include_host_intent() {
     let cli = Cli {
         command: Commands::Host(HostArgs {
@@ -89,4 +111,37 @@ fn host_config_load_options_include_host_intent() {
     assert_eq!(options.command_intent, CommandIntent::Host);
     assert_eq!(options.overrides.agent_kind, Some(AgentKind::Custom));
     assert_eq!(options.overrides.agent_mode, Some(AgentMode::Acp));
+}
+
+#[rstest]
+fn host_config_load_options_leave_agent_overrides_unset_when_flags_are_omitted() {
+    let cli = Cli {
+        command: Commands::Host(HostArgs {
+            agent: None,
+            mode: None,
+        }),
+        config: None,
+        engine_socket: None,
+        image: None,
+    };
+
+    let options = cli.config_load_options();
+
+    assert_eq!(options.command_intent, CommandIntent::Host);
+    assert!(options.overrides.agent_kind.is_none());
+    assert!(options.overrides.agent_mode.is_none());
+}
+
+#[rstest]
+fn cli_parses_snake_case_hosted_agent_mode_values() {
+    let cli = Cli::try_parse_from(["podbot", "host", "--agent-mode", "codex_app_server"])
+        .expect("snake_case hosted mode should parse");
+
+    let options = cli.config_load_options();
+
+    assert_eq!(options.command_intent, CommandIntent::Host);
+    assert_eq!(
+        options.overrides.agent_mode,
+        Some(AgentMode::CodexAppServer)
+    );
 }

--- a/src/config/agent.rs
+++ b/src/config/agent.rs
@@ -28,6 +28,18 @@ pub enum AgentMode {
     Acp,
 }
 
+impl AgentMode {
+    /// Returns the `snake_case` token representation used in configuration and CLI.
+    #[must_use]
+    pub const fn as_token(&self) -> &'static str {
+        match self {
+            Self::Podbot => "podbot",
+            Self::CodexAppServer => "codex_app_server",
+            Self::Acp => "acp",
+        }
+    }
+}
+
 /// Agent execution configuration.
 #[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(default)]

--- a/src/config/agent.rs
+++ b/src/config/agent.rs
@@ -1,0 +1,61 @@
+//! Agent configuration types for interactive and hosted runtimes.
+
+use serde::{Deserialize, Serialize};
+
+/// The kind of AI agent to run.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum AgentKind {
+    /// Claude Code agent.
+    #[default]
+    Claude,
+    /// `OpenAI` Codex agent.
+    Codex,
+    /// Custom operator-supplied agent launcher.
+    Custom,
+}
+
+/// The execution mode for the agent.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AgentMode {
+    /// Run the agent in podbot-managed interactive mode.
+    #[default]
+    Podbot,
+    /// Run the agent as a Codex App Server.
+    CodexAppServer,
+    /// Run the agent as an ACP server.
+    Acp,
+}
+
+/// Agent execution configuration.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(default)]
+pub struct AgentConfig {
+    /// The type of agent to run.
+    pub kind: AgentKind,
+
+    /// The execution mode for the agent.
+    pub mode: AgentMode,
+
+    /// The executable used for custom hosted agents.
+    pub command: Option<String>,
+
+    /// Additional command-line arguments passed to the hosted agent.
+    pub args: Vec<String>,
+
+    /// Environment variable names copied from the host into the agent runtime.
+    pub env_allowlist: Vec<String>,
+}
+
+impl Default for AgentConfig {
+    fn default() -> Self {
+        Self {
+            kind: AgentKind::Claude,
+            mode: AgentMode::Podbot,
+            command: None,
+            args: Vec::new(),
+            env_allowlist: Vec::new(),
+        }
+    }
+}

--- a/src/config/env_vars.rs
+++ b/src/config/env_vars.rs
@@ -14,6 +14,8 @@ use crate::error::{ConfigError, Result};
 enum EnvVarType {
     /// String value (always accepted).
     String,
+    /// Comma-separated list of strings.
+    StringList,
     /// Boolean value (`true`/`false`). Invalid values return an error.
     Bool,
     /// Unsigned 64-bit integer. Invalid values return an error.
@@ -89,10 +91,40 @@ const ENV_VAR_SPECS: &[EnvVarSpec] = &[
         path: &["agent", "mode"],
         var_type: EnvVarType::String,
     },
+    EnvVarSpec {
+        env_var: "PODBOT_AGENT_COMMAND",
+        path: &["agent", "command"],
+        var_type: EnvVarType::String,
+    },
+    EnvVarSpec {
+        env_var: "PODBOT_AGENT_ARGS",
+        path: &["agent", "args"],
+        var_type: EnvVarType::StringList,
+    },
+    EnvVarSpec {
+        env_var: "PODBOT_AGENT_ENV_ALLOWLIST",
+        path: &["agent", "env_allowlist"],
+        var_type: EnvVarType::StringList,
+    },
     // Workspace fields
+    EnvVarSpec {
+        env_var: "PODBOT_WORKSPACE_SOURCE",
+        path: &["workspace", "source"],
+        var_type: EnvVarType::String,
+    },
     EnvVarSpec {
         env_var: "PODBOT_WORKSPACE_BASE_DIR",
         path: &["workspace", "base_dir"],
+        var_type: EnvVarType::String,
+    },
+    EnvVarSpec {
+        env_var: "PODBOT_WORKSPACE_HOST_PATH",
+        path: &["workspace", "host_path"],
+        var_type: EnvVarType::String,
+    },
+    EnvVarSpec {
+        env_var: "PODBOT_WORKSPACE_CONTAINER_PATH",
+        path: &["workspace", "container_path"],
         var_type: EnvVarType::String,
     },
     // Creds fields
@@ -105,6 +137,32 @@ const ENV_VAR_SPECS: &[EnvVarSpec] = &[
         env_var: "PODBOT_CREDS_COPY_CODEX",
         path: &["creds", "copy_codex"],
         var_type: EnvVarType::Bool,
+    },
+    // MCP hosting fields
+    EnvVarSpec {
+        env_var: "PODBOT_MCP_BIND_STRATEGY",
+        path: &["mcp", "bind_strategy"],
+        var_type: EnvVarType::String,
+    },
+    EnvVarSpec {
+        env_var: "PODBOT_MCP_IDLE_TIMEOUT_SECS",
+        path: &["mcp", "idle_timeout_secs"],
+        var_type: EnvVarType::U64,
+    },
+    EnvVarSpec {
+        env_var: "PODBOT_MCP_MAX_MESSAGE_SIZE_BYTES",
+        path: &["mcp", "max_message_size_bytes"],
+        var_type: EnvVarType::U64,
+    },
+    EnvVarSpec {
+        env_var: "PODBOT_MCP_AUTH_TOKEN_POLICY",
+        path: &["mcp", "auth_token_policy"],
+        var_type: EnvVarType::String,
+    },
+    EnvVarSpec {
+        env_var: "PODBOT_MCP_ALLOWED_ORIGIN_POLICY",
+        path: &["mcp", "allowed_origin_policy"],
+        var_type: EnvVarType::String,
     },
 ];
 
@@ -215,6 +273,14 @@ pub(crate) fn collect_env_vars<E: mockable::Env>(env: &E) -> Result<Value> {
         // Invalid values return an error immediately (fail-fast).
         let json_value = match spec.var_type {
             EnvVarType::String => Value::String(raw_value),
+            EnvVarType::StringList => Value::Array(
+                raw_value
+                    .split(',')
+                    .map(str::trim)
+                    .filter(|value| !value.is_empty())
+                    .map(|value| Value::String(value.to_owned()))
+                    .collect(),
+            ),
             EnvVarType::Bool => match raw_value.parse::<bool>() {
                 Ok(b) => Value::Bool(b),
                 Err(_) => {

--- a/src/config/hosting.rs
+++ b/src/config/hosting.rs
@@ -1,0 +1,68 @@
+//! MCP hosting defaults for hosted app-server mode.
+
+use serde::{Deserialize, Serialize};
+
+/// Address binding strategy for HTTP-facing MCP bridges.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum McpBindStrategy {
+    /// Reach the bridge through the host gateway instead of a wide-open port.
+    #[default]
+    HostGateway,
+    /// Bind only to loopback.
+    Loopback,
+}
+
+/// Auth-token issuance policy for hosted MCP bridges.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum McpAuthTokenPolicy {
+    /// Issue one token per workspace.
+    #[default]
+    PerWorkspace,
+    /// Issue a distinct token per wire.
+    PerWire,
+}
+
+/// Cross-origin policy for HTTP-facing MCP endpoints.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum McpAllowedOriginPolicy {
+    /// Accept same-origin requests only.
+    #[default]
+    SameOrigin,
+    /// Accept any origin.
+    Any,
+}
+
+/// Defaults for Podbot-managed MCP hosting.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(default)]
+pub struct McpConfig {
+    /// Network exposure strategy for the bridge.
+    pub bind_strategy: McpBindStrategy,
+
+    /// Idle timeout in seconds before an unused bridge is retired.
+    pub idle_timeout_secs: u64,
+
+    /// Maximum message size accepted by the bridge.
+    pub max_message_size_bytes: u64,
+
+    /// Auth-token issuance policy for hosted bridges.
+    pub auth_token_policy: McpAuthTokenPolicy,
+
+    /// Allowed-origin policy for HTTP-facing endpoints.
+    pub allowed_origin_policy: McpAllowedOriginPolicy,
+}
+
+impl Default for McpConfig {
+    fn default() -> Self {
+        Self {
+            bind_strategy: McpBindStrategy::HostGateway,
+            idle_timeout_secs: 900,
+            max_message_size_bytes: 1_048_576,
+            auth_token_policy: McpAuthTokenPolicy::PerWorkspace,
+            allowed_origin_policy: McpAllowedOriginPolicy::SameOrigin,
+        }
+    }
+}

--- a/src/config/load_options.rs
+++ b/src/config/load_options.rs
@@ -7,6 +7,8 @@
 
 use camino::Utf8PathBuf;
 
+use crate::config::{AgentKind, AgentMode, CommandIntent};
+
 /// High-precedence configuration overrides supplied by the host application.
 ///
 /// These overrides are applied after configuration files and environment
@@ -18,13 +20,22 @@ pub struct ConfigOverrides {
 
     /// Sandbox container image reference.
     pub image: Option<String>,
+
+    /// Agent kind override supplied by the host adapter.
+    pub agent_kind: Option<AgentKind>,
+
+    /// Agent mode override supplied by the host adapter.
+    pub agent_mode: Option<AgentMode>,
 }
 
 impl ConfigOverrides {
     /// Returns whether no overrides are present.
     #[must_use]
     pub const fn is_empty(&self) -> bool {
-        self.engine_socket.is_none() && self.image.is_none()
+        self.engine_socket.is_none()
+            && self.image.is_none()
+            && self.agent_kind.is_none()
+            && self.agent_mode.is_none()
     }
 }
 
@@ -48,6 +59,9 @@ pub struct ConfigLoadOptions {
 
     /// High-precedence overrides supplied by the host application.
     pub overrides: ConfigOverrides,
+
+    /// Command intent used for semantic validation after layer merging.
+    pub command_intent: CommandIntent,
 }
 
 impl Default for ConfigLoadOptions {
@@ -56,6 +70,7 @@ impl Default for ConfigLoadOptions {
             config_path_hint: None,
             discover_config: true,
             overrides: ConfigOverrides::default(),
+            command_intent: CommandIntent::Any,
         }
     }
 }

--- a/src/config/loader.rs
+++ b/src/config/loader.rs
@@ -140,14 +140,16 @@ pub fn load_config_with_env<E: mockable::Env>(
     }
 
     // Layer 4: host overrides.
-    let overrides = build_overrides(&options.overrides);
+    let overrides = build_overrides(&options.overrides)?;
     if !overrides.is_null() {
         composer.push_cli(overrides);
     }
 
     // Merge all layers into the final configuration.
-    let config =
+    let merged_config =
         AppConfig::merge_from_layers(composer.layers()).map_err(ConfigError::OrthoConfig)?;
+    let mut config = merged_config;
+    config.normalize_and_validate(options.command_intent)?;
 
     Ok(config)
 }
@@ -190,9 +192,9 @@ fn discover_config_path(enabled: bool) -> Option<Utf8PathBuf> {
 }
 
 /// Build a JSON value containing host overrides.
-fn build_overrides(overrides: &ConfigOverrides) -> serde_json::Value {
+fn build_overrides(overrides: &ConfigOverrides) -> Result<serde_json::Value> {
     if overrides.is_empty() {
-        return serde_json::Value::Null;
+        return Ok(serde_json::Value::Null);
     }
 
     let mut json_overrides = serde_json::Map::new();
@@ -208,5 +210,29 @@ fn build_overrides(overrides: &ConfigOverrides) -> serde_json::Value {
         json_overrides.insert("image".to_owned(), serde_json::Value::String(image.clone()));
     }
 
-    serde_json::Value::Object(json_overrides)
+    if overrides.agent_kind.is_some() || overrides.agent_mode.is_some() {
+        let mut agent = serde_json::Map::new();
+
+        if let Some(kind) = overrides.agent_kind {
+            agent.insert(
+                "kind".to_owned(),
+                serde_json::to_value(kind).map_err(|error| ConfigError::ParseError {
+                    message: format!("failed to serialize agent kind override: {error}"),
+                })?,
+            );
+        }
+
+        if let Some(mode) = overrides.agent_mode {
+            agent.insert(
+                "mode".to_owned(),
+                serde_json::to_value(mode).map_err(|error| ConfigError::ParseError {
+                    message: format!("failed to serialize agent mode override: {error}"),
+                })?,
+            );
+        }
+
+        json_overrides.insert("agent".to_owned(), serde_json::Value::Object(agent));
+    }
+
+    Ok(serde_json::Value::Object(json_overrides))
 }

--- a/src/config/loader.rs
+++ b/src/config/loader.rs
@@ -87,7 +87,8 @@ fn load_config_file(path: &Utf8PathBuf, composer: &mut MergeComposer) -> Result<
 /// 3. Environment variables prefixed with `PODBOT_`
 /// 4. Host-supplied overrides (for example CLI flags)
 ///
-/// Later sources override earlier ones.
+/// Later sources override earlier ones. After merging, the configuration is
+/// semantically validated via `AppConfig::normalize_and_validate`.
 ///
 /// # Errors
 ///
@@ -96,6 +97,8 @@ fn load_config_file(path: &Utf8PathBuf, composer: &mut MergeComposer) -> Result<
 /// - Invalid typed environment variable values (e.g., non-boolean for
 ///   `PODBOT_SANDBOX_PRIVILEGED`)
 /// - Missing required fields after merge
+/// - Semantic validation failures (`ConfigError::InvalidValue`) such as illegal
+///   `(command_intent, agent.mode)` combinations or missing host mount paths
 pub fn load_config(options: &ConfigLoadOptions) -> Result<AppConfig> {
     let env = mockable::DefaultEnv::new();
     load_config_with_env(&env, options)
@@ -104,7 +107,8 @@ pub fn load_config(options: &ConfigLoadOptions) -> Result<AppConfig> {
 /// Load configuration with full layer precedence using an injected environment.
 ///
 /// This function enables deterministic unit and behavioural testing without
-/// mutating the process environment.
+/// mutating the process environment. After merging, the configuration is
+/// semantically validated via `AppConfig::normalize_and_validate`.
 ///
 /// # Errors
 ///
@@ -113,6 +117,8 @@ pub fn load_config(options: &ConfigLoadOptions) -> Result<AppConfig> {
 /// - Invalid typed environment variable values (e.g., non-boolean for
 ///   `PODBOT_SANDBOX_PRIVILEGED`)
 /// - `OrthoConfig` merge failures after layer composition
+/// - Semantic validation failures (`ConfigError::InvalidValue`) such as illegal
+///   `(command_intent, agent.mode)` combinations or missing host mount paths
 pub fn load_config_with_env<E: mockable::Env>(
     env: &E,
     options: &ConfigLoadOptions,

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -21,6 +21,7 @@
 //!
 //! [workspace]
 //! base_dir = "/work"
+//! source = "github_clone"
 //!
 //! [sandbox]
 //! privileged = false
@@ -30,20 +31,29 @@
 //! [agent]
 //! kind = "claude"
 //! mode = "podbot"
+//!
+//! [mcp]
+//! bind_strategy = "host_gateway"
 //! ```
 
+mod agent;
 mod env_vars;
+mod hosting;
 mod load_options;
 mod loader;
 mod types;
+mod validation;
+mod workspace;
 
 #[cfg(test)]
 mod tests;
 
+pub use agent::{AgentConfig, AgentKind, AgentMode};
 pub use env_vars::env_var_names;
+pub use hosting::{McpAllowedOriginPolicy, McpAuthTokenPolicy, McpBindStrategy, McpConfig};
 pub use load_options::{ConfigLoadOptions, ConfigOverrides};
 pub use loader::{load_config, load_config_with_env};
-pub use types::{
-    AgentConfig, AgentKind, AgentMode, AppConfig, CredsConfig, GitHubConfig, SandboxConfig,
-    SelinuxLabelMode, WorkspaceConfig,
-};
+pub use types::{AppConfig, CredsConfig, GitHubConfig, SandboxConfig, SelinuxLabelMode};
+pub use validation::CommandIntent;
+pub(crate) use workspace::default_host_mount_container_path;
+pub use workspace::{WorkspaceConfig, WorkspaceSource};

--- a/src/config/tests/hosting_layer_precedence_tests.rs
+++ b/src/config/tests/hosting_layer_precedence_tests.rs
@@ -1,0 +1,54 @@
+//! Layer precedence tests for hosting-era config fields.
+
+use ortho_config::serde_json::json;
+use rstest::rstest;
+
+use crate::config::tests::helpers::{create_composer_with_defaults, merge_config};
+use crate::config::{AgentKind, AgentMode, AppConfig, WorkspaceSource};
+
+#[rstest]
+fn hosting_fields_merge_across_layers() {
+    let mut composer = create_composer_with_defaults().expect("composer creation should succeed");
+
+    composer.push_file(
+        json!({
+            "workspace": {
+                "source": "host_mount",
+                "host_path": "/from/file/project"
+            },
+            "agent": {
+                "kind": "custom",
+                "command": "opencode"
+            }
+        }),
+        None,
+    );
+    composer.push_environment(json!({
+        "workspace": {
+            "container_path": "/from/env/workspace"
+        },
+        "agent": {
+            "mode": "acp",
+            "args": ["serve"]
+        }
+    }));
+
+    let mut config: AppConfig = merge_config(composer).expect("merge should succeed");
+    config
+        .normalize_and_validate(crate::config::CommandIntent::Host)
+        .expect("hosting config should validate");
+
+    assert_eq!(config.workspace.source, WorkspaceSource::HostMount);
+    assert_eq!(
+        config.workspace.host_path,
+        Some("/from/file/project".into())
+    );
+    assert_eq!(
+        config.workspace.container_path,
+        Some("/from/env/workspace".into())
+    );
+    assert_eq!(config.agent.kind, AgentKind::Custom);
+    assert_eq!(config.agent.mode, AgentMode::Acp);
+    assert_eq!(config.agent.command.as_deref(), Some("opencode"));
+    assert_eq!(config.agent.args, vec![String::from("serve")]);
+}

--- a/src/config/tests/hosting_types_tests.rs
+++ b/src/config/tests/hosting_types_tests.rs
@@ -1,0 +1,126 @@
+//! Hosting-era schema defaults and serialization tests.
+
+use camino::Utf8PathBuf;
+use rstest::rstest;
+
+use crate::config::{
+    AgentKind, AgentMode, AppConfig, CommandIntent, McpAllowedOriginPolicy, McpAuthTokenPolicy,
+    McpBindStrategy, WorkspaceSource,
+};
+
+#[rstest]
+fn app_config_hosting_defaults_are_explicit() {
+    let config = AppConfig::default();
+
+    assert_eq!(config.workspace.source, WorkspaceSource::GithubClone);
+    assert!(config.workspace.host_path.is_none());
+    assert!(config.workspace.container_path.is_none());
+    assert!(config.agent.command.is_none());
+    assert!(config.agent.args.is_empty());
+    assert!(config.agent.env_allowlist.is_empty());
+    assert_eq!(config.mcp.bind_strategy, McpBindStrategy::HostGateway);
+    assert_eq!(config.mcp.idle_timeout_secs, 900);
+    assert_eq!(config.mcp.max_message_size_bytes, 1_048_576);
+    assert_eq!(
+        config.mcp.auth_token_policy,
+        McpAuthTokenPolicy::PerWorkspace
+    );
+    assert_eq!(
+        config.mcp.allowed_origin_policy,
+        McpAllowedOriginPolicy::SameOrigin
+    );
+}
+
+#[rstest]
+#[case(AgentKind::Custom, "custom")]
+fn agent_kind_supports_hosting_variants(#[case] kind: AgentKind, #[case] expected: &str) {
+    let serialised = serde_json::to_string(&kind).expect("serialisation should succeed");
+    assert_eq!(serialised, format!("\"{expected}\""));
+}
+
+#[rstest]
+#[case(AgentMode::CodexAppServer, "codex_app_server")]
+#[case(AgentMode::Acp, "acp")]
+fn agent_mode_supports_hosting_variants(#[case] mode: AgentMode, #[case] expected: &str) {
+    let serialised = serde_json::to_string(&mode).expect("serialisation should succeed");
+    assert_eq!(serialised, format!("\"{expected}\""));
+}
+
+#[rstest]
+#[case(WorkspaceSource::GithubClone, "github_clone")]
+#[case(WorkspaceSource::HostMount, "host_mount")]
+fn workspace_source_serialises_to_snake_case(
+    #[case] source: WorkspaceSource,
+    #[case] expected: &str,
+) {
+    let serialised = serde_json::to_string(&source).expect("serialisation should succeed");
+    assert_eq!(serialised, format!("\"{expected}\""));
+}
+
+#[rstest]
+fn hosting_toml_deserialises() {
+    let config = toml::from_str::<AppConfig>(
+        r#"
+        [workspace]
+        source = "host_mount"
+        host_path = "/tmp/project"
+
+        [agent]
+        kind = "custom"
+        mode = "acp"
+        command = "opencode"
+        args = ["acp"]
+        env_allowlist = ["OPENAI_API_KEY", "ANTHROPIC_API_KEY"]
+
+        [mcp]
+        bind_strategy = "loopback"
+        idle_timeout_secs = 30
+        max_message_size_bytes = 4096
+        auth_token_policy = "per_wire"
+        allowed_origin_policy = "any"
+    "#,
+    )
+    .expect("TOML parsing should succeed");
+
+    assert_eq!(config.workspace.source, WorkspaceSource::HostMount);
+    assert_eq!(
+        config.workspace.host_path,
+        Some(Utf8PathBuf::from("/tmp/project"))
+    );
+    assert_eq!(config.agent.kind, AgentKind::Custom);
+    assert_eq!(config.agent.mode, AgentMode::Acp);
+    assert_eq!(config.agent.command.as_deref(), Some("opencode"));
+    assert_eq!(config.agent.args, vec![String::from("acp")]);
+    assert_eq!(
+        config.agent.env_allowlist,
+        vec![
+            String::from("OPENAI_API_KEY"),
+            String::from("ANTHROPIC_API_KEY"),
+        ]
+    );
+    assert_eq!(config.mcp.bind_strategy, McpBindStrategy::Loopback);
+    assert_eq!(config.mcp.idle_timeout_secs, 30);
+    assert_eq!(config.mcp.max_message_size_bytes, 4096);
+    assert_eq!(config.mcp.auth_token_policy, McpAuthTokenPolicy::PerWire);
+    assert_eq!(
+        config.mcp.allowed_origin_policy,
+        McpAllowedOriginPolicy::Any
+    );
+}
+
+#[rstest]
+fn normalize_and_validate_adds_host_mount_container_default() {
+    let mut config = AppConfig::default();
+    config.workspace.source = WorkspaceSource::HostMount;
+    config.workspace.host_path = Some(Utf8PathBuf::from("/tmp/project"));
+    config.agent.mode = AgentMode::CodexAppServer;
+
+    config
+        .normalize_and_validate(CommandIntent::Host)
+        .expect("host config should validate");
+
+    assert_eq!(
+        config.workspace.container_path,
+        Some(Utf8PathBuf::from("/workspace"))
+    );
+}

--- a/src/config/tests/hosting_types_tests.rs
+++ b/src/config/tests/hosting_types_tests.rs
@@ -1,11 +1,14 @@
 //! Hosting-era schema defaults and serialization tests.
 
+use std::collections::HashMap;
+
 use camino::Utf8PathBuf;
+use mockable::MockEnv;
 use rstest::rstest;
 
 use crate::config::{
-    AgentKind, AgentMode, AppConfig, CommandIntent, McpAllowedOriginPolicy, McpAuthTokenPolicy,
-    McpBindStrategy, WorkspaceSource,
+    AgentKind, AgentMode, AppConfig, CommandIntent, ConfigLoadOptions, McpAllowedOriginPolicy,
+    McpAuthTokenPolicy, McpBindStrategy, WorkspaceSource, load_config_with_env,
 };
 
 #[rstest]
@@ -28,6 +31,53 @@ fn app_config_hosting_defaults_are_explicit() {
     assert_eq!(
         config.mcp.allowed_origin_policy,
         McpAllowedOriginPolicy::SameOrigin
+    );
+}
+
+#[rstest]
+fn app_config_mcp_env_overrides() {
+    let values = HashMap::from([
+        (
+            String::from("PODBOT_MCP_BIND_STRATEGY"),
+            String::from("loopback"),
+        ),
+        (
+            String::from("PODBOT_MCP_IDLE_TIMEOUT_SECS"),
+            String::from("123"),
+        ),
+        (
+            String::from("PODBOT_MCP_MAX_MESSAGE_SIZE_BYTES"),
+            String::from("4096"),
+        ),
+        (
+            String::from("PODBOT_MCP_AUTH_TOKEN_POLICY"),
+            String::from("per_wire"),
+        ),
+        (
+            String::from("PODBOT_MCP_ALLOWED_ORIGIN_POLICY"),
+            String::from("any"),
+        ),
+    ]);
+    let mut env = MockEnv::new();
+    env.expect_string()
+        .returning(move |key| values.get(key).cloned());
+
+    let config = load_config_with_env(
+        &env,
+        &ConfigLoadOptions {
+            discover_config: false,
+            ..ConfigLoadOptions::default()
+        },
+    )
+    .expect("config should load successfully from MCP env overrides");
+
+    assert_eq!(config.mcp.bind_strategy, McpBindStrategy::Loopback);
+    assert_eq!(config.mcp.idle_timeout_secs, 123);
+    assert_eq!(config.mcp.max_message_size_bytes, 4096);
+    assert_eq!(config.mcp.auth_token_policy, McpAuthTokenPolicy::PerWire);
+    assert_eq!(
+        config.mcp.allowed_origin_policy,
+        McpAllowedOriginPolicy::Any
     );
 }
 

--- a/src/config/tests/mod.rs
+++ b/src/config/tests/mod.rs
@@ -7,6 +7,9 @@
 //! - [`layer_precedence_tests`] - `MergeComposer` layer precedence tests
 
 mod helpers;
+mod hosting_layer_precedence_tests;
+mod hosting_types_tests;
 mod layer_precedence_tests;
+mod semantic_validation_tests;
 mod types_tests;
 mod validation;

--- a/src/config/tests/mod.rs
+++ b/src/config/tests/mod.rs
@@ -5,6 +5,9 @@
 //! - [`types_tests`] - Basic type and serialisation tests
 //! - [`validation`] - `GitHubConfig` validation tests
 //! - [`layer_precedence_tests`] - `MergeComposer` layer precedence tests
+//! - [`hosting_layer_precedence_tests`] - Hosting layer precedence tests
+//! - [`hosting_types_tests`] - Hosting schema defaults and serialisation tests
+//! - [`semantic_validation_tests`] - Hosted-era semantic validation tests
 
 mod helpers;
 mod hosting_layer_precedence_tests;

--- a/src/config/tests/semantic_validation_tests.rs
+++ b/src/config/tests/semantic_validation_tests.rs
@@ -6,6 +6,15 @@ use rstest::rstest;
 use crate::config::{AgentKind, AgentMode, AppConfig, CommandIntent, WorkspaceSource};
 use crate::error::{ConfigError, PodbotError};
 
+struct HostMountCase {
+    host_path: Option<Utf8PathBuf>,
+    container_path: Option<Utf8PathBuf>,
+    agent_mode: Option<AgentMode>,
+    intent: CommandIntent,
+    expected_field: &'static str,
+    expected_reason: &'static str,
+}
+
 #[rstest]
 fn custom_agent_requires_command() {
     let mut config = AppConfig::default();
@@ -32,15 +41,50 @@ fn builtin_agents_reject_custom_command_fields() {
 }
 
 #[rstest]
-fn host_mount_requires_host_path() {
+#[case(HostMountCase {
+    host_path: None,
+    container_path: None,
+    agent_mode: Some(AgentMode::Acp),
+    intent: CommandIntent::Host,
+    expected_field: "workspace.host_path",
+    expected_reason: "requires `workspace.host_path`",
+})]
+#[case(HostMountCase {
+    host_path: Some(Utf8PathBuf::from("relative/host")),
+    container_path: None,
+    agent_mode: None,
+    intent: CommandIntent::Any,
+    expected_field: "workspace.host_path",
+    expected_reason: "must be an absolute host path",
+})]
+#[case(HostMountCase {
+    host_path: Some(Utf8PathBuf::from("/tmp/project")),
+    container_path: Some(Utf8PathBuf::from("relative/container")),
+    agent_mode: None,
+    intent: CommandIntent::Any,
+    expected_field: "workspace.container_path",
+    expected_reason: "must be an absolute container path",
+})]
+fn host_mount_validation(#[case] case: HostMountCase) {
     let mut config = AppConfig::default();
     config.workspace.source = WorkspaceSource::HostMount;
-    config.agent.mode = AgentMode::Acp;
+
+    if let Some(path) = case.host_path {
+        config.workspace.host_path = Some(path);
+    }
+
+    if let Some(path) = case.container_path {
+        config.workspace.container_path = Some(path);
+    }
+
+    if let Some(agent_mode) = case.agent_mode {
+        config.agent.mode = agent_mode;
+    }
 
     assert_invalid_value(
-        config.normalize_and_validate(CommandIntent::Host),
-        "workspace.host_path",
-        "requires `workspace.host_path`",
+        config.normalize_and_validate(case.intent),
+        case.expected_field,
+        case.expected_reason,
     );
 }
 
@@ -87,33 +131,6 @@ fn workspace_base_dir_rejects_relative_path() {
     assert_invalid_value(
         config.normalize_and_validate(CommandIntent::Any),
         "workspace.base_dir",
-        "must be an absolute container path",
-    );
-}
-
-#[rstest]
-fn host_mount_rejects_relative_host_path() {
-    let mut config = AppConfig::default();
-    config.workspace.source = WorkspaceSource::HostMount;
-    config.workspace.host_path = Some(Utf8PathBuf::from("relative/host"));
-
-    assert_invalid_value(
-        config.normalize_and_validate(CommandIntent::Any),
-        "workspace.host_path",
-        "must be an absolute host path",
-    );
-}
-
-#[rstest]
-fn host_mount_rejects_relative_container_path() {
-    let mut config = AppConfig::default();
-    config.workspace.source = WorkspaceSource::HostMount;
-    config.workspace.host_path = Some(Utf8PathBuf::from("/tmp/project"));
-    config.workspace.container_path = Some(Utf8PathBuf::from("relative/container"));
-
-    assert_invalid_value(
-        config.normalize_and_validate(CommandIntent::Any),
-        "workspace.container_path",
         "must be an absolute container path",
     );
 }

--- a/src/config/tests/semantic_validation_tests.rs
+++ b/src/config/tests/semantic_validation_tests.rs
@@ -41,6 +41,18 @@ fn builtin_agents_reject_custom_command_fields() {
 }
 
 #[rstest]
+fn builtin_agents_reject_custom_args_fields() {
+    let mut config = AppConfig::default();
+    config.agent.args = vec![String::from("--verbose")];
+
+    assert_invalid_value(
+        config.normalize_and_validate(CommandIntent::Run),
+        "agent.args",
+        "built-in agent kinds",
+    );
+}
+
+#[rstest]
 #[case(HostMountCase {
     host_path: None,
     container_path: None,
@@ -112,13 +124,24 @@ fn host_rejects_podbot_mode() {
 }
 
 #[rstest]
-fn github_clone_rejects_host_mount_fields() {
+#[case("workspace.host_path", Some(Utf8PathBuf::from("/tmp/project")), None)]
+#[case(
+    "workspace.container_path",
+    None,
+    Some(Utf8PathBuf::from("/workspace"))
+)]
+fn github_clone_rejects_host_mount_fields(
+    #[case] field: &str,
+    #[case] host_path: Option<Utf8PathBuf>,
+    #[case] container_path: Option<Utf8PathBuf>,
+) {
     let mut config = AppConfig::default();
-    config.workspace.host_path = Some(Utf8PathBuf::from("/tmp/project"));
+    config.workspace.host_path = host_path;
+    config.workspace.container_path = container_path;
 
     assert_invalid_value(
         config.normalize_and_validate(CommandIntent::Any),
-        "workspace.host_path",
+        field,
         "only valid when `workspace.source = \"host_mount\"`",
     );
 }

--- a/src/config/tests/semantic_validation_tests.rs
+++ b/src/config/tests/semantic_validation_tests.rs
@@ -79,6 +79,61 @@ fn github_clone_rejects_host_mount_fields() {
     );
 }
 
+#[rstest]
+fn workspace_base_dir_rejects_relative_path() {
+    let mut config = AppConfig::default();
+    config.workspace.base_dir = Utf8PathBuf::from("relative/path");
+
+    assert_invalid_value(
+        config.normalize_and_validate(CommandIntent::Any),
+        "workspace.base_dir",
+        "must be an absolute container path",
+    );
+}
+
+#[rstest]
+fn host_mount_rejects_relative_host_path() {
+    let mut config = AppConfig::default();
+    config.workspace.source = WorkspaceSource::HostMount;
+    config.workspace.host_path = Some(Utf8PathBuf::from("relative/host"));
+
+    assert_invalid_value(
+        config.normalize_and_validate(CommandIntent::Any),
+        "workspace.host_path",
+        "must be an absolute host path",
+    );
+}
+
+#[rstest]
+fn host_mount_rejects_relative_container_path() {
+    let mut config = AppConfig::default();
+    config.workspace.source = WorkspaceSource::HostMount;
+    config.workspace.host_path = Some(Utf8PathBuf::from("/tmp/project"));
+    config.workspace.container_path = Some(Utf8PathBuf::from("relative/container"));
+
+    assert_invalid_value(
+        config.normalize_and_validate(CommandIntent::Any),
+        "workspace.container_path",
+        "must be an absolute container path",
+    );
+}
+
+#[rstest]
+fn env_allowlist_rejects_empty_or_whitespace_entries() {
+    let mut config = AppConfig::default();
+    config.agent.env_allowlist = vec![
+        String::from("OPENAI_API_KEY"),
+        String::new(),
+        String::from("   "),
+    ];
+
+    assert_invalid_value(
+        config.normalize_and_validate(CommandIntent::Any),
+        "agent.env_allowlist",
+        "must not be empty or whitespace only",
+    );
+}
+
 fn assert_invalid_value(
     result: crate::error::Result<()>,
     expected_field: &str,

--- a/src/config/tests/semantic_validation_tests.rs
+++ b/src/config/tests/semantic_validation_tests.rs
@@ -1,0 +1,99 @@
+//! Semantic validation tests for hosted-era configuration rules.
+
+use camino::Utf8PathBuf;
+use rstest::rstest;
+
+use crate::config::{AgentKind, AgentMode, AppConfig, CommandIntent, WorkspaceSource};
+use crate::error::{ConfigError, PodbotError};
+
+#[rstest]
+fn custom_agent_requires_command() {
+    let mut config = AppConfig::default();
+    config.agent.kind = AgentKind::Custom;
+    config.agent.mode = AgentMode::CodexAppServer;
+
+    assert_invalid_value(
+        config.normalize_and_validate(CommandIntent::Host),
+        "agent.command",
+        "requires a non-empty",
+    );
+}
+
+#[rstest]
+fn builtin_agents_reject_custom_command_fields() {
+    let mut config = AppConfig::default();
+    config.agent.command = Some(String::from("opencode"));
+
+    assert_invalid_value(
+        config.normalize_and_validate(CommandIntent::Run),
+        "agent.command",
+        "built-in agent kinds",
+    );
+}
+
+#[rstest]
+fn host_mount_requires_host_path() {
+    let mut config = AppConfig::default();
+    config.workspace.source = WorkspaceSource::HostMount;
+    config.agent.mode = AgentMode::Acp;
+
+    assert_invalid_value(
+        config.normalize_and_validate(CommandIntent::Host),
+        "workspace.host_path",
+        "requires `workspace.host_path`",
+    );
+}
+
+#[rstest]
+fn run_rejects_hosted_modes() {
+    let mut config = AppConfig::default();
+    config.agent.mode = AgentMode::CodexAppServer;
+
+    assert_invalid_value(
+        config.normalize_and_validate(CommandIntent::Run),
+        "agent.mode",
+        "hosted modes require `podbot host`",
+    );
+}
+
+#[rstest]
+fn host_rejects_podbot_mode() {
+    let mut config = AppConfig::default();
+
+    assert_invalid_value(
+        config.normalize_and_validate(CommandIntent::Host),
+        "agent.mode",
+        "interactive mode requires `podbot run`",
+    );
+}
+
+#[rstest]
+fn github_clone_rejects_host_mount_fields() {
+    let mut config = AppConfig::default();
+    config.workspace.host_path = Some(Utf8PathBuf::from("/tmp/project"));
+
+    assert_invalid_value(
+        config.normalize_and_validate(CommandIntent::Any),
+        "workspace.host_path",
+        "only valid when `workspace.source = \"host_mount\"`",
+    );
+}
+
+fn assert_invalid_value(
+    result: crate::error::Result<()>,
+    expected_field: &str,
+    expected_reason: &str,
+) {
+    let error = result.expect_err("validation should fail");
+
+    match error {
+        PodbotError::Config(ConfigError::InvalidValue { field, reason }) => {
+            assert_eq!(field, expected_field);
+            assert!(
+                reason.contains(expected_reason),
+                "expected '{reason}' to mention '{expected_reason}'"
+            );
+        }
+        other => panic!("expected ConfigError::InvalidValue, got {other:?}"),
+    }
+}

--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -1,9 +1,11 @@
-//! Configuration data types for podbot.
+//! Root configuration types for podbot.
 
 use camino::Utf8PathBuf;
 use ortho_config::{OrthoConfig, OrthoResult, PostMergeContext, PostMergeHook};
 use serde::{Deserialize, Serialize};
 use smart_default::SmartDefault;
+
+use crate::config::{AgentConfig, McpConfig, WorkspaceConfig};
 
 /// How `SELinux` labels should be applied to the container.
 ///
@@ -22,26 +24,6 @@ pub enum SelinuxLabelMode {
     DisableForContainer,
 }
 
-/// The kind of AI agent to run.
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "lowercase")]
-pub enum AgentKind {
-    /// Claude Code agent.
-    #[default]
-    Claude,
-    /// `OpenAI` Codex agent.
-    Codex,
-}
-
-/// The execution mode for the agent.
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "lowercase")]
-pub enum AgentMode {
-    /// Run the agent in podbot-managed mode.
-    #[default]
-    Podbot,
-}
-
 /// `GitHub` App configuration.
 #[derive(Debug, Clone, Default, Deserialize, Serialize)]
 pub struct GitHubConfig {
@@ -58,21 +40,14 @@ pub struct GitHubConfig {
 impl GitHubConfig {
     /// Validates that all required `GitHub` fields are present and non-zero.
     ///
-    /// This method checks that `app_id`, `installation_id`, and `private_key_path`
-    /// are all set and that numeric IDs are non-zero. Call this before performing
-    /// `GitHub` operations that require authentication.
-    ///
-    /// # Note on zero values
-    ///
-    /// `GitHub` never issues `app_id` or `installation_id` values of `0`, so this
-    /// validation treats `Some(0)` as invalid to catch default/placeholder values
-    /// early.
+    /// This method checks that `app_id`, `installation_id`, and
+    /// `private_key_path` are all set and that numeric IDs are non-zero. Call
+    /// this before performing `GitHub` operations that require authentication.
     ///
     /// # Errors
     ///
-    /// Returns `ConfigError::MissingRequired` if any required field is `None`
-    /// or if numeric IDs are zero, with the field names listed in the error
-    /// message.
+    /// Returns `ConfigError::MissingRequired` when any required field is
+    /// missing or contains the sentinel value `0`.
     pub fn validate(&self) -> crate::error::Result<()> {
         let mut missing = Vec::new();
         if self.app_id.is_none() || self.app_id == Some(0) {
@@ -94,10 +69,6 @@ impl GitHubConfig {
     }
 
     /// Returns whether all `GitHub` credentials are properly configured.
-    ///
-    /// This checks that all three fields (`app_id`, `installation_id`,
-    /// `private_key_path`) are present and that numeric IDs are non-zero.
-    /// This mirrors the checks performed by [`validate()`](Self::validate).
     #[must_use]
     pub fn is_configured(&self) -> bool {
         self.app_id.is_some_and(|v| v != 0)
@@ -121,42 +92,6 @@ pub struct SandboxConfig {
     pub selinux_label_mode: SelinuxLabelMode,
 }
 
-/// Agent execution configuration.
-#[derive(Debug, Clone, Deserialize, Serialize)]
-#[serde(default)]
-pub struct AgentConfig {
-    /// The type of agent to run.
-    pub kind: AgentKind,
-
-    /// The execution mode for the agent.
-    pub mode: AgentMode,
-}
-
-impl Default for AgentConfig {
-    fn default() -> Self {
-        Self {
-            kind: AgentKind::Claude,
-            mode: AgentMode::Podbot,
-        }
-    }
-}
-
-/// Workspace configuration.
-#[derive(Debug, Clone, Deserialize, Serialize)]
-#[serde(default)]
-pub struct WorkspaceConfig {
-    /// Base directory for cloned repositories inside the container.
-    pub base_dir: Utf8PathBuf,
-}
-
-impl Default for WorkspaceConfig {
-    fn default() -> Self {
-        Self {
-            base_dir: Utf8PathBuf::from("/work"),
-        }
-    }
-}
-
 /// Credential copying configuration.
 #[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(default)]
@@ -178,27 +113,6 @@ impl Default for CredsConfig {
 }
 
 /// Root application configuration.
-///
-/// This structure is loaded from configuration files, environment variables,
-/// and host overrides with layered precedence. The precedence order (lowest to
-/// highest) is: defaults, configuration file, environment variables, host
-/// overrides (for example CLI flags).
-///
-/// Configuration files are discovered in this order (see `loader.rs`):
-/// 1. Host-provided config-path hint (for example `--config`), if it exists
-/// 2. Path specified via `PODBOT_CONFIG_PATH` environment variable, if present
-/// 3. `~/.config/podbot/config.toml` (XDG default)
-/// 4. `~/.podbot.toml` (dotfile in home directory)
-///
-/// When a host provides a config-path hint, `PODBOT_CONFIG_PATH` is ignored
-/// even if the hint is missing. This avoids surprising behaviour where a
-/// missing explicit path would silently pick up a different configuration via
-/// the process environment.
-///
-/// Note: Discovery is implemented in `loader.rs` using `ConfigDiscovery` rather
-/// than via `OrthoConfig`'s `discovery(...)` attribute, because we need to
-/// expose a `Clap`-free library API that still supports CLI-provided config
-/// paths and fail-fast environment validation.
 #[derive(Debug, Clone, Default, Deserialize, Serialize, OrthoConfig)]
 #[ortho_config(prefix = "PODBOT", post_merge_hook)]
 pub struct AppConfig {
@@ -232,13 +146,15 @@ pub struct AppConfig {
     #[serde(default)]
     #[ortho_config(skip_cli)]
     pub creds: CredsConfig,
+
+    /// Defaults for hosted MCP bridge behaviour.
+    #[serde(default)]
+    #[ortho_config(skip_cli)]
+    pub mcp: McpConfig,
 }
 
 impl PostMergeHook for AppConfig {
     fn post_merge(&mut self, _ctx: &PostMergeContext) -> OrthoResult<()> {
-        // Placeholder for future normalisation logic.
-        // GitHub validation is intentionally NOT performed here because
-        // not all commands require GitHub credentials (e.g., `podbot ps`).
         Ok(())
     }
 }

--- a/src/config/validation.rs
+++ b/src/config/validation.rs
@@ -1,0 +1,201 @@
+//! Semantic configuration normalization and legality checks.
+
+use crate::config::{
+    AgentKind, AgentMode, AppConfig, WorkspaceSource, default_host_mount_container_path,
+};
+use crate::error::{ConfigError, Result};
+
+/// High-level command intent used for configuration legality checks.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum CommandIntent {
+    /// Validate only schema-internal invariants.
+    #[default]
+    Any,
+    /// Validate the config as an interactive `podbot run` request.
+    Run,
+    /// Validate the config as a hosted `podbot host` request.
+    Host,
+}
+
+impl AppConfig {
+    /// Normalize dependent defaults and validate semantic configuration rules.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use podbot::config::{AppConfig, CommandIntent, WorkspaceSource};
+    ///
+    /// let mut config = AppConfig::default();
+    /// config.workspace.source = WorkspaceSource::HostMount;
+    /// config.workspace.host_path = Some("/tmp/project".into());
+    ///
+    /// config.normalize_and_validate(CommandIntent::Host)?;
+    /// assert_eq!(
+    ///     config.workspace.container_path.as_deref(),
+    ///     Some("/workspace")
+    /// );
+    /// # Ok::<(), podbot::error::PodbotError>(())
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns `ConfigError::InvalidValue` when semantic config invariants are
+    /// violated, such as illegal `(command, agent.mode)` combinations or
+    /// missing `host_mount` paths.
+    pub fn normalize_and_validate(&mut self, intent: CommandIntent) -> Result<()> {
+        self.apply_dependent_defaults();
+        self.validate_agent_config()?;
+        self.validate_workspace_config()?;
+        self.validate_command_intent(intent)
+    }
+
+    fn apply_dependent_defaults(&mut self) {
+        if self.workspace.source == WorkspaceSource::HostMount
+            && self.workspace.container_path.is_none()
+        {
+            self.workspace.container_path = Some(default_host_mount_container_path());
+        }
+    }
+
+    fn validate_agent_config(&self) -> Result<()> {
+        validate_env_allowlist(&self.agent.env_allowlist)?;
+
+        match self.agent.kind {
+            AgentKind::Custom => validate_custom_agent(self),
+            AgentKind::Claude | AgentKind::Codex => validate_builtin_agent(self),
+        }
+    }
+
+    fn validate_workspace_config(&self) -> Result<()> {
+        if !self.workspace.base_dir.is_absolute() {
+            return invalid_value(
+                "workspace.base_dir",
+                "workspace.base_dir must be an absolute container path",
+            );
+        }
+
+        match self.workspace.source {
+            WorkspaceSource::GithubClone => validate_github_clone_workspace(self),
+            WorkspaceSource::HostMount => validate_host_mount_workspace(self),
+        }
+    }
+
+    fn validate_command_intent(&self, intent: CommandIntent) -> Result<()> {
+        match intent {
+            CommandIntent::Any => Ok(()),
+            CommandIntent::Run if self.agent.mode == AgentMode::Podbot => Ok(()),
+            CommandIntent::Run => invalid_value(
+                "agent.mode",
+                "hosted modes require `podbot host`; use `agent.mode = \"podbot\"` for `podbot run`",
+            ),
+            CommandIntent::Host if self.agent.mode != AgentMode::Podbot => Ok(()),
+            CommandIntent::Host => invalid_value(
+                "agent.mode",
+                "interactive mode requires `podbot run`; use `codex_app_server` or `acp` with `podbot host`",
+            ),
+        }
+    }
+}
+
+fn validate_env_allowlist(values: &[String]) -> Result<()> {
+    for value in values {
+        if value.trim().is_empty() {
+            return invalid_value(
+                "agent.env_allowlist",
+                "agent.env_allowlist entries must not be empty",
+            );
+        }
+    }
+
+    Ok(())
+}
+
+fn validate_custom_agent(config: &AppConfig) -> Result<()> {
+    match config.agent.command.as_deref().map(str::trim) {
+        Some(command) if !command.is_empty() => Ok(()),
+        _ => invalid_value(
+            "agent.command",
+            "`agent.kind = \"custom\"` requires a non-empty `agent.command`",
+        ),
+    }
+}
+
+fn validate_builtin_agent(config: &AppConfig) -> Result<()> {
+    if config.agent.command.is_some() {
+        return invalid_value(
+            "agent.command",
+            "built-in agent kinds must not set `agent.command`; use `agent.kind = \"custom\"` instead",
+        );
+    }
+
+    if !config.agent.args.is_empty() {
+        return invalid_value(
+            "agent.args",
+            "built-in agent kinds must not set `agent.args`; use `agent.kind = \"custom\"` instead",
+        );
+    }
+
+    Ok(())
+}
+
+fn validate_github_clone_workspace(config: &AppConfig) -> Result<()> {
+    if config.workspace.host_path.is_some() {
+        return invalid_value(
+            "workspace.host_path",
+            "`workspace.host_path` is only valid when `workspace.source = \"host_mount\"`",
+        );
+    }
+
+    if config.workspace.container_path.is_some() {
+        return invalid_value(
+            "workspace.container_path",
+            "`workspace.container_path` is only valid when `workspace.source = \"host_mount\"`",
+        );
+    }
+
+    Ok(())
+}
+
+fn validate_host_mount_workspace(config: &AppConfig) -> Result<()> {
+    let host_path = config.workspace.host_path.as_ref().ok_or_else(|| {
+        crate::error::PodbotError::from(ConfigError::InvalidValue {
+            field: String::from("workspace.host_path"),
+            reason: String::from(
+                "`workspace.source = \"host_mount\"` requires `workspace.host_path`",
+            ),
+        })
+    })?;
+
+    if !host_path.is_absolute() {
+        return invalid_value(
+            "workspace.host_path",
+            "workspace.host_path must be an absolute host path",
+        );
+    }
+
+    let container_path = config.workspace.container_path.as_ref().ok_or_else(|| {
+        crate::error::PodbotError::from(ConfigError::InvalidValue {
+            field: String::from("workspace.container_path"),
+            reason: String::from(
+                "`workspace.source = \"host_mount\"` requires `workspace.container_path`",
+            ),
+        })
+    })?;
+
+    if !container_path.is_absolute() {
+        return invalid_value(
+            "workspace.container_path",
+            "workspace.container_path must be an absolute container path",
+        );
+    }
+
+    Ok(())
+}
+
+fn invalid_value<T>(field: &str, reason: &str) -> Result<T> {
+    Err(ConfigError::InvalidValue {
+        field: field.to_owned(),
+        reason: reason.to_owned(),
+    }
+    .into())
+}

--- a/src/config/validation.rs
+++ b/src/config/validation.rs
@@ -111,7 +111,7 @@ fn is_intent_legal(intent: CommandIntent, mode: AgentMode) -> bool {
     match intent {
         CommandIntent::Any => true,
         CommandIntent::Run => mode == AgentMode::Podbot,
-        CommandIntent::Host => mode != AgentMode::Podbot,
+        CommandIntent::Host => matches!(mode, AgentMode::CodexAppServer | AgentMode::Acp),
     }
 }
 
@@ -189,14 +189,13 @@ fn validate_host_mount_workspace(config: &AppConfig) -> Result<()> {
         );
     }
 
-    let default_container_path = default_host_mount_container_path();
-    let container_path = config
-        .workspace
-        .container_path
-        .as_ref()
-        .unwrap_or(&default_container_path);
+    // Validate container_path absoluteness; apply_dependent_defaults ensures it's set
+    let is_absolute = config.workspace.container_path.as_ref().map_or_else(
+        || default_host_mount_container_path().is_absolute(),
+        |p| p.is_absolute(),
+    );
 
-    if !container_path.is_absolute() {
+    if !is_absolute {
         return invalid_value(
             "workspace.container_path",
             "workspace.container_path must be an absolute container path",

--- a/src/config/validation.rs
+++ b/src/config/validation.rs
@@ -177,12 +177,12 @@ fn validate_host_mount_workspace(config: &AppConfig) -> Result<()> {
         );
     }
 
-    let Some(container_path) = config.workspace.container_path.as_ref() else {
-        return invalid_value(
-            "workspace.container_path",
-            "`workspace.source = \"host_mount\"` requires `workspace.container_path`",
-        );
-    };
+    let default_container_path = default_host_mount_container_path();
+    let container_path = config
+        .workspace
+        .container_path
+        .as_ref()
+        .unwrap_or(&default_container_path);
 
     if !container_path.is_absolute() {
         return invalid_value(

--- a/src/config/validation.rs
+++ b/src/config/validation.rs
@@ -90,15 +90,15 @@ impl AppConfig {
                 CommandIntent::Run => invalid_value(
                     "agent.mode",
                     format!(
-                        "hosted modes require `podbot host`; use `agent.mode = \"podbot\"` for `podbot run` (current mode: {:?})",
-                        self.agent.mode
+                        "hosted modes require `podbot host`; use `agent.mode = \"podbot\"` for `podbot run` (current mode: {})",
+                        self.agent.mode.as_token()
                     ),
                 ),
                 CommandIntent::Host => invalid_value(
                     "agent.mode",
                     format!(
-                        "interactive mode requires `podbot run`; use `codex_app_server` or `acp` with `podbot host` (current mode: {:?})",
-                        self.agent.mode
+                        "interactive mode requires `podbot run`; use `codex_app_server` or `acp` with `podbot host` (current mode: {})",
+                        self.agent.mode.as_token()
                     ),
                 ),
                 CommandIntent::Any => Ok(()), // unreachable: Any is always legal

--- a/src/config/validation.rs
+++ b/src/config/validation.rs
@@ -86,12 +86,18 @@ impl AppConfig {
             CommandIntent::Run if self.agent.mode == AgentMode::Podbot => Ok(()),
             CommandIntent::Run => invalid_value(
                 "agent.mode",
-                "hosted modes require `podbot host`; use `agent.mode = \"podbot\"` for `podbot run`",
+                format!(
+                    "hosted modes require `podbot host`; use `agent.mode = \"podbot\"` for `podbot run` (current mode: {:?})",
+                    self.agent.mode
+                ),
             ),
             CommandIntent::Host if self.agent.mode != AgentMode::Podbot => Ok(()),
             CommandIntent::Host => invalid_value(
                 "agent.mode",
-                "interactive mode requires `podbot run`; use `codex_app_server` or `acp` with `podbot host`",
+                format!(
+                    "interactive mode requires `podbot run`; use `codex_app_server` or `acp` with `podbot host` (current mode: {:?})",
+                    self.agent.mode
+                ),
             ),
         }
     }
@@ -102,7 +108,7 @@ fn validate_env_allowlist(values: &[String]) -> Result<()> {
         if value.trim().is_empty() {
             return invalid_value(
                 "agent.env_allowlist",
-                "agent.env_allowlist entries must not be empty",
+                "agent.env_allowlist entries must not be empty or whitespace only",
             );
         }
     }
@@ -157,14 +163,12 @@ fn validate_github_clone_workspace(config: &AppConfig) -> Result<()> {
 }
 
 fn validate_host_mount_workspace(config: &AppConfig) -> Result<()> {
-    let host_path = config.workspace.host_path.as_ref().ok_or_else(|| {
-        crate::error::PodbotError::from(ConfigError::InvalidValue {
-            field: String::from("workspace.host_path"),
-            reason: String::from(
-                "`workspace.source = \"host_mount\"` requires `workspace.host_path`",
-            ),
-        })
-    })?;
+    let Some(host_path) = config.workspace.host_path.as_ref() else {
+        return invalid_value(
+            "workspace.host_path",
+            "`workspace.source = \"host_mount\"` requires `workspace.host_path`",
+        );
+    };
 
     if !host_path.is_absolute() {
         return invalid_value(
@@ -173,14 +177,12 @@ fn validate_host_mount_workspace(config: &AppConfig) -> Result<()> {
         );
     }
 
-    let container_path = config.workspace.container_path.as_ref().ok_or_else(|| {
-        crate::error::PodbotError::from(ConfigError::InvalidValue {
-            field: String::from("workspace.container_path"),
-            reason: String::from(
-                "`workspace.source = \"host_mount\"` requires `workspace.container_path`",
-            ),
-        })
-    })?;
+    let Some(container_path) = config.workspace.container_path.as_ref() else {
+        return invalid_value(
+            "workspace.container_path",
+            "`workspace.source = \"host_mount\"` requires `workspace.container_path`",
+        );
+    };
 
     if !container_path.is_absolute() {
         return invalid_value(
@@ -192,10 +194,10 @@ fn validate_host_mount_workspace(config: &AppConfig) -> Result<()> {
     Ok(())
 }
 
-fn invalid_value<T>(field: &str, reason: &str) -> Result<T> {
+fn invalid_value<T>(field: &str, reason: impl Into<String>) -> Result<T> {
     Err(ConfigError::InvalidValue {
         field: field.to_owned(),
-        reason: reason.to_owned(),
+        reason: reason.into(),
     }
     .into())
 }

--- a/src/config/validation.rs
+++ b/src/config/validation.rs
@@ -23,16 +23,18 @@ impl AppConfig {
     /// # Examples
     ///
     /// ```rust
-    /// use podbot::config::{AppConfig, CommandIntent, WorkspaceSource};
+    /// use camino::Utf8Path;
+    /// use podbot::config::{AgentMode, AppConfig, CommandIntent, WorkspaceSource};
     ///
     /// let mut config = AppConfig::default();
+    /// config.agent.mode = AgentMode::CodexAppServer;
     /// config.workspace.source = WorkspaceSource::HostMount;
     /// config.workspace.host_path = Some("/tmp/project".into());
     ///
     /// config.normalize_and_validate(CommandIntent::Host)?;
     /// assert_eq!(
     ///     config.workspace.container_path.as_deref(),
-    ///     Some("/workspace")
+    ///     Some(Utf8Path::new("/workspace"))
     /// );
     /// # Ok::<(), podbot::error::PodbotError>(())
     /// ```
@@ -81,25 +83,35 @@ impl AppConfig {
     }
 
     fn validate_command_intent(&self, intent: CommandIntent) -> Result<()> {
-        match intent {
-            CommandIntent::Any => Ok(()),
-            CommandIntent::Run if self.agent.mode == AgentMode::Podbot => Ok(()),
-            CommandIntent::Run => invalid_value(
-                "agent.mode",
-                format!(
-                    "hosted modes require `podbot host`; use `agent.mode = \"podbot\"` for `podbot run` (current mode: {:?})",
-                    self.agent.mode
+        if is_intent_legal(intent, self.agent.mode) {
+            Ok(())
+        } else {
+            match intent {
+                CommandIntent::Run => invalid_value(
+                    "agent.mode",
+                    format!(
+                        "hosted modes require `podbot host`; use `agent.mode = \"podbot\"` for `podbot run` (current mode: {:?})",
+                        self.agent.mode
+                    ),
                 ),
-            ),
-            CommandIntent::Host if self.agent.mode != AgentMode::Podbot => Ok(()),
-            CommandIntent::Host => invalid_value(
-                "agent.mode",
-                format!(
-                    "interactive mode requires `podbot run`; use `codex_app_server` or `acp` with `podbot host` (current mode: {:?})",
-                    self.agent.mode
+                CommandIntent::Host => invalid_value(
+                    "agent.mode",
+                    format!(
+                        "interactive mode requires `podbot run`; use `codex_app_server` or `acp` with `podbot host` (current mode: {:?})",
+                        self.agent.mode
+                    ),
                 ),
-            ),
+                CommandIntent::Any => Ok(()), // unreachable: Any is always legal
+            }
         }
+    }
+}
+
+fn is_intent_legal(intent: CommandIntent, mode: AgentMode) -> bool {
+    match intent {
+        CommandIntent::Any => true,
+        CommandIntent::Run => mode == AgentMode::Podbot,
+        CommandIntent::Host => mode != AgentMode::Podbot,
     }
 }
 

--- a/src/config/workspace.rs
+++ b/src/config/workspace.rs
@@ -1,0 +1,49 @@
+//! Workspace configuration types for clone-based and host-mounted sessions.
+
+use camino::Utf8PathBuf;
+use serde::{Deserialize, Serialize};
+
+/// The source of the workspace content exposed to the agent.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum WorkspaceSource {
+    /// Clone a repository into the sandbox-managed workspace path.
+    #[default]
+    GithubClone,
+    /// Bind-mount an explicit host directory into the sandbox.
+    HostMount,
+}
+
+/// Workspace configuration.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(default)]
+pub struct WorkspaceConfig {
+    /// Where the workspace content comes from.
+    pub source: WorkspaceSource,
+
+    /// Base directory for cloned repositories inside the container.
+    pub base_dir: Utf8PathBuf,
+
+    /// Host directory to mount when `source = "host_mount"`.
+    pub host_path: Option<Utf8PathBuf>,
+
+    /// Container path where the mounted host workspace appears.
+    pub container_path: Option<Utf8PathBuf>,
+}
+
+impl Default for WorkspaceConfig {
+    fn default() -> Self {
+        Self {
+            source: WorkspaceSource::GithubClone,
+            base_dir: Utf8PathBuf::from("/work"),
+            host_path: None,
+            container_path: None,
+        }
+    }
+}
+
+/// Default container path used for host-mounted workspaces.
+#[must_use]
+pub(crate) fn default_host_mount_container_path() -> Utf8PathBuf {
+    Utf8PathBuf::from("/workspace")
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -106,7 +106,7 @@ fn host_agent_cli(config: &AppConfig, _args: &HostArgs) -> CommandOutcome {
         config.agent.kind, config.agent.mode
     );
     println!("Hosted agent orchestration not yet implemented.");
-    CommandOutcome::Success
+    CommandOutcome::CommandExit { code: 1 }
 }
 
 /// CLI adapter for the token refresh daemon.

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,7 +15,7 @@ use std::io::IsTerminal;
 use clap::Parser;
 use eyre::{Report, Result as EyreResult};
 use podbot::api::{CommandOutcome, ExecParams};
-use podbot::cli::{Cli, Commands, ExecArgs, RunArgs, StopArgs, TokenDaemonArgs};
+use podbot::cli::{Cli, Commands, ExecArgs, HostArgs, RunArgs, StopArgs, TokenDaemonArgs};
 use podbot::config::{AppConfig, load_config};
 use podbot::engine::{EngineConnector, ExecMode, SocketResolver};
 use podbot::error::{ContainerError, Result as PodbotResult};
@@ -58,6 +58,7 @@ fn run(
 ) -> PodbotResult<CommandOutcome> {
     match &cli.command {
         Commands::Run(args) => run_agent_cli(config, args, runtime_handle),
+        Commands::Host(args) => Ok(host_agent_cli(config, args)),
         Commands::TokenDaemon(args) => run_token_daemon_cli(args),
         Commands::Ps => list_containers_cli(),
         Commands::Stop(args) => stop_container_cli(args),
@@ -83,8 +84,8 @@ fn run_agent_cli(
     }
 
     println!(
-        "Running {:?} agent for repository {} on branch {}",
-        args.agent, args.repo, args.branch
+        "Running {:?} agent in {:?} mode for repository {} on branch {}",
+        config.agent.kind, config.agent.mode, args.repo, args.branch
     );
     if let Some(ref socket) = config.engine_socket {
         println!("Using engine socket: {socket}");
@@ -95,6 +96,17 @@ fn run_agent_cli(
     let result = podbot::api::run_agent(config)?;
     println!("Container orchestration not yet implemented.");
     Ok(result)
+}
+
+/// CLI adapter for hosted app-server execution.
+#[expect(clippy::print_stdout, reason = "CLI output is the intended behaviour")]
+fn host_agent_cli(config: &AppConfig, _args: &HostArgs) -> CommandOutcome {
+    println!(
+        "Hosting {:?} agent in {:?} mode",
+        config.agent.kind, config.agent.mode
+    );
+    println!("Hosted agent orchestration not yet implemented.");
+    CommandOutcome::Success
 }
 
 /// CLI adapter for the token refresh daemon.

--- a/tests/bdd_config_helpers.rs
+++ b/tests/bdd_config_helpers.rs
@@ -4,7 +4,7 @@ use camino::Utf8PathBuf;
 use ortho_config::MergeComposer;
 use ortho_config::serde_json::json;
 use podbot::config::{
-    AgentKind, AgentMode, AppConfig, GitHubConfig, SandboxConfig, WorkspaceConfig,
+    AgentKind, AgentMode, AppConfig, GitHubConfig, SandboxConfig, WorkspaceConfig, WorkspaceSource,
 };
 use podbot::error::{ConfigError, PodbotError};
 use rstest::fixture;
@@ -62,7 +62,10 @@ fn set_sandbox_config(config_state: &ConfigState, privileged: bool, mount_dev_fu
 fn set_workspace_base_dir(config_state: &ConfigState, base_dir: &str) {
     let config = AppConfig {
         workspace: WorkspaceConfig {
+            source: WorkspaceSource::GithubClone,
             base_dir: Utf8PathBuf::from(base_dir),
+            host_path: None,
+            container_path: None,
         },
         ..Default::default()
     };

--- a/tests/bdd_config_loader_helpers.rs
+++ b/tests/bdd_config_loader_helpers.rs
@@ -175,6 +175,8 @@ fn host_overrides_set_image_to(
     options.overrides = ConfigOverrides {
         engine_socket: None,
         image: Some(image),
+        agent_kind: None,
+        agent_mode: None,
     };
     set_options(config_loader_state, options);
     Ok(())

--- a/tests/bdd_hosting_config.rs
+++ b/tests/bdd_hosting_config.rs
@@ -1,0 +1,46 @@
+//! Behavioural tests for hosted-era configuration semantics.
+
+mod bdd_hosting_config_helpers;
+
+pub use bdd_hosting_config_helpers::{HostingConfigState, hosting_config_state};
+use rstest_bdd_macros::scenario;
+
+#[scenario(
+    path = "tests/features/hosting_configuration.feature",
+    name = "Legacy interactive configuration remains valid"
+)]
+fn legacy_interactive_configuration_remains_valid(hosting_config_state: HostingConfigState) {
+    let _ = hosting_config_state;
+}
+
+#[scenario(
+    path = "tests/features/hosting_configuration.feature",
+    name = "Host-mounted workspace gains a default container path"
+)]
+fn host_mounted_workspace_gains_a_default_container_path(hosting_config_state: HostingConfigState) {
+    let _ = hosting_config_state;
+}
+
+#[scenario(
+    path = "tests/features/hosting_configuration.feature",
+    name = "Run intent rejects hosted modes"
+)]
+fn run_intent_rejects_hosted_modes(hosting_config_state: HostingConfigState) {
+    let _ = hosting_config_state;
+}
+
+#[scenario(
+    path = "tests/features/hosting_configuration.feature",
+    name = "Host mount requires an explicit host path"
+)]
+fn host_mount_requires_an_explicit_host_path(hosting_config_state: HostingConfigState) {
+    let _ = hosting_config_state;
+}
+
+#[scenario(
+    path = "tests/features/hosting_configuration.feature",
+    name = "Custom agents require an explicit command"
+)]
+fn custom_agents_require_an_explicit_command(hosting_config_state: HostingConfigState) {
+    let _ = hosting_config_state;
+}

--- a/tests/bdd_hosting_config_helpers.rs
+++ b/tests/bdd_hosting_config_helpers.rs
@@ -37,37 +37,38 @@ fn the_default_application_configuration(
     Ok(())
 }
 
-#[expect(
-    clippy::too_many_arguments,
-    reason = "the helper signature is fixed by the task requirements"
-)]
-#[expect(
-    clippy::unnecessary_wraps,
-    reason = "the helper returns StepResult to match the step helper contract"
-)]
-fn configure_hosting_state(
-    hosting_config_state: &HostingConfigState,
+#[derive(Default)]
+struct HostingStateOptions {
     workspace_source: Option<WorkspaceSource>,
     workspace_host_path: Option<Utf8PathBuf>,
     agent_kind: Option<AgentKind>,
     agent_mode: Option<AgentMode>,
     agent_command: Option<String>,
+}
+
+fn configure_hosting_state(
+    hosting_config_state: &HostingConfigState,
+    opts: HostingStateOptions,
 ) -> StepResult<()> {
+    if hosting_config_state.config.get().is_some() {
+        return Err(String::from("config should not already be set"));
+    }
+
     let mut config = AppConfig::default();
 
-    if let Some(source) = workspace_source {
+    if let Some(source) = opts.workspace_source {
         config.workspace.source = source;
     }
-    if let Some(host_path) = workspace_host_path {
+    if let Some(host_path) = opts.workspace_host_path {
         config.workspace.host_path = Some(host_path);
     }
-    if let Some(kind) = agent_kind {
+    if let Some(kind) = opts.agent_kind {
         config.agent.kind = kind;
     }
-    if let Some(mode) = agent_mode {
+    if let Some(mode) = opts.agent_mode {
         config.agent.mode = mode;
     }
-    config.agent.command = agent_command;
+    config.agent.command = opts.agent_command;
 
     hosting_config_state.config.set(config);
     Ok(())
@@ -83,13 +84,14 @@ fn a_host_mounted_custom_agent_configuration(
 ) -> StepResult<()> {
     configure_hosting_state(
         hosting_config_state,
-        Some(WorkspaceSource::HostMount),
-        Some(Utf8PathBuf::from("/tmp/project")),
-        Some(AgentKind::Custom),
-        Some(AgentMode::CodexAppServer),
-        Some(String::from("opencode")),
-    )?;
-    Ok(())
+        HostingStateOptions {
+            workspace_source: Some(WorkspaceSource::HostMount),
+            workspace_host_path: Some(Utf8PathBuf::from("/tmp/project")),
+            agent_kind: Some(AgentKind::Custom),
+            agent_mode: Some(AgentMode::CodexAppServer),
+            agent_command: Some(String::from("opencode")),
+        },
+    )
 }
 
 #[given("a hosted custom agent configuration")]
@@ -102,13 +104,13 @@ fn a_hosted_custom_agent_configuration(
 ) -> StepResult<()> {
     configure_hosting_state(
         hosting_config_state,
-        None,
-        None,
-        Some(AgentKind::Custom),
-        Some(AgentMode::Acp),
-        Some(String::from("opencode")),
-    )?;
-    Ok(())
+        HostingStateOptions {
+            agent_kind: Some(AgentKind::Custom),
+            agent_mode: Some(AgentMode::Acp),
+            agent_command: Some(String::from("opencode")),
+            ..Default::default()
+        },
+    )
 }
 
 #[given("a host-mounted workspace without a host path")]
@@ -121,13 +123,14 @@ fn a_host_mounted_workspace_without_a_host_path(
 ) -> StepResult<()> {
     configure_hosting_state(
         hosting_config_state,
-        Some(WorkspaceSource::HostMount),
-        None,
-        Some(AgentKind::Custom),
-        Some(AgentMode::CodexAppServer),
-        Some(String::from("opencode")),
-    )?;
-    Ok(())
+        HostingStateOptions {
+            workspace_source: Some(WorkspaceSource::HostMount),
+            agent_kind: Some(AgentKind::Custom),
+            agent_mode: Some(AgentMode::CodexAppServer),
+            agent_command: Some(String::from("opencode")),
+            ..Default::default()
+        },
+    )
 }
 
 #[given("a custom hosted agent without a command")]
@@ -140,13 +143,12 @@ fn a_custom_hosted_agent_without_a_command(
 ) -> StepResult<()> {
     configure_hosting_state(
         hosting_config_state,
-        None,
-        None,
-        Some(AgentKind::Custom),
-        Some(AgentMode::CodexAppServer),
-        None,
-    )?;
-    Ok(())
+        HostingStateOptions {
+            agent_kind: Some(AgentKind::Custom),
+            agent_mode: Some(AgentMode::CodexAppServer),
+            ..Default::default()
+        },
+    )
 }
 
 #[when("the configuration is normalized for run intent")]

--- a/tests/bdd_hosting_config_helpers.rs
+++ b/tests/bdd_hosting_config_helpers.rs
@@ -1,4 +1,8 @@
 //! Behavioural step definitions for hosted-era configuration semantics.
+#![allow(
+    unfulfilled_lint_expectations,
+    reason = "the task requires preserving step-level expectations after extracting the shared setup helper"
+)]
 
 use camino::Utf8PathBuf;
 use podbot::config::{AgentKind, AgentMode, AppConfig, CommandIntent, WorkspaceSource};
@@ -33,6 +37,42 @@ fn the_default_application_configuration(
     Ok(())
 }
 
+#[expect(
+    clippy::too_many_arguments,
+    reason = "the helper signature is fixed by the task requirements"
+)]
+#[expect(
+    clippy::unnecessary_wraps,
+    reason = "the helper returns StepResult to match the step helper contract"
+)]
+fn configure_hosting_state(
+    hosting_config_state: &HostingConfigState,
+    workspace_source: Option<WorkspaceSource>,
+    workspace_host_path: Option<Utf8PathBuf>,
+    agent_kind: Option<AgentKind>,
+    agent_mode: Option<AgentMode>,
+    agent_command: Option<String>,
+) -> StepResult<()> {
+    let mut config = AppConfig::default();
+
+    if let Some(source) = workspace_source {
+        config.workspace.source = source;
+    }
+    if let Some(host_path) = workspace_host_path {
+        config.workspace.host_path = Some(host_path);
+    }
+    if let Some(kind) = agent_kind {
+        config.agent.kind = kind;
+    }
+    if let Some(mode) = agent_mode {
+        config.agent.mode = mode;
+    }
+    config.agent.command = agent_command;
+
+    hosting_config_state.config.set(config);
+    Ok(())
+}
+
 #[given("a host-mounted custom agent configuration")]
 #[expect(
     clippy::unnecessary_wraps,
@@ -41,13 +81,14 @@ fn the_default_application_configuration(
 fn a_host_mounted_custom_agent_configuration(
     hosting_config_state: &HostingConfigState,
 ) -> StepResult<()> {
-    let mut config = AppConfig::default();
-    config.workspace.source = WorkspaceSource::HostMount;
-    config.workspace.host_path = Some(Utf8PathBuf::from("/tmp/project"));
-    config.agent.kind = AgentKind::Custom;
-    config.agent.mode = AgentMode::CodexAppServer;
-    config.agent.command = Some(String::from("opencode"));
-    hosting_config_state.config.set(config);
+    configure_hosting_state(
+        hosting_config_state,
+        Some(WorkspaceSource::HostMount),
+        Some(Utf8PathBuf::from("/tmp/project")),
+        Some(AgentKind::Custom),
+        Some(AgentMode::CodexAppServer),
+        Some(String::from("opencode")),
+    )?;
     Ok(())
 }
 
@@ -59,11 +100,14 @@ fn a_host_mounted_custom_agent_configuration(
 fn a_hosted_custom_agent_configuration(
     hosting_config_state: &HostingConfigState,
 ) -> StepResult<()> {
-    let mut config = AppConfig::default();
-    config.agent.kind = AgentKind::Custom;
-    config.agent.mode = AgentMode::Acp;
-    config.agent.command = Some(String::from("opencode"));
-    hosting_config_state.config.set(config);
+    configure_hosting_state(
+        hosting_config_state,
+        None,
+        None,
+        Some(AgentKind::Custom),
+        Some(AgentMode::Acp),
+        Some(String::from("opencode")),
+    )?;
     Ok(())
 }
 
@@ -75,12 +119,14 @@ fn a_hosted_custom_agent_configuration(
 fn a_host_mounted_workspace_without_a_host_path(
     hosting_config_state: &HostingConfigState,
 ) -> StepResult<()> {
-    let mut config = AppConfig::default();
-    config.workspace.source = WorkspaceSource::HostMount;
-    config.agent.kind = AgentKind::Custom;
-    config.agent.mode = AgentMode::CodexAppServer;
-    config.agent.command = Some(String::from("opencode"));
-    hosting_config_state.config.set(config);
+    configure_hosting_state(
+        hosting_config_state,
+        Some(WorkspaceSource::HostMount),
+        None,
+        Some(AgentKind::Custom),
+        Some(AgentMode::CodexAppServer),
+        Some(String::from("opencode")),
+    )?;
     Ok(())
 }
 
@@ -92,10 +138,14 @@ fn a_host_mounted_workspace_without_a_host_path(
 fn a_custom_hosted_agent_without_a_command(
     hosting_config_state: &HostingConfigState,
 ) -> StepResult<()> {
-    let mut config = AppConfig::default();
-    config.agent.kind = AgentKind::Custom;
-    config.agent.mode = AgentMode::CodexAppServer;
-    hosting_config_state.config.set(config);
+    configure_hosting_state(
+        hosting_config_state,
+        None,
+        None,
+        Some(AgentKind::Custom),
+        Some(AgentMode::CodexAppServer),
+        None,
+    )?;
     Ok(())
 }
 

--- a/tests/bdd_hosting_config_helpers.rs
+++ b/tests/bdd_hosting_config_helpers.rs
@@ -74,82 +74,99 @@ fn configure_hosting_state(
     Ok(())
 }
 
-#[given("a host-mounted custom agent configuration")]
-#[expect(
-    clippy::unnecessary_wraps,
-    reason = "rstest-bdd step functions return StepResult for consistency"
-)]
-fn a_host_mounted_custom_agent_configuration(
-    hosting_config_state: &HostingConfigState,
-) -> StepResult<()> {
-    configure_hosting_state(
-        hosting_config_state,
-        HostingStateOptions {
-            workspace_source: Some(WorkspaceSource::HostMount),
-            workspace_host_path: Some(Utf8PathBuf::from("/tmp/project")),
-            agent_kind: Some(AgentKind::Custom),
-            agent_mode: Some(AgentMode::CodexAppServer),
-            agent_command: Some(String::from("opencode")),
-        },
-    )
+macro_rules! given_hosting_step {
+    (
+        $fn_name:ident,
+        $given_str:literal,
+        {
+            workspace_source: $workspace_source:expr,
+            workspace_host_path: $workspace_host_path:expr,
+            agent_kind: $agent_kind:expr,
+            agent_mode: $agent_mode:expr,
+            agent_command: $agent_command:expr $(,)?
+        }
+    ) => {
+        #[given($given_str)]
+        #[expect(
+            clippy::unnecessary_wraps,
+            reason = "rstest-bdd step functions return StepResult for consistency"
+        )]
+        fn $fn_name(hosting_config_state: &HostingConfigState) -> StepResult<()> {
+            configure_hosting_state(
+                hosting_config_state,
+                HostingStateOptions {
+                    workspace_source: $workspace_source,
+                    workspace_host_path: $workspace_host_path,
+                    agent_kind: $agent_kind,
+                    agent_mode: $agent_mode,
+                    agent_command: $agent_command,
+                },
+            )
+        }
+    };
+    (
+        $fn_name:ident,
+        $given_str:literal,
+        { $($field:ident: $value:expr),* $(,)? }
+    ) => {
+        #[given($given_str)]
+        #[expect(
+            clippy::unnecessary_wraps,
+            reason = "rstest-bdd step functions return StepResult for consistency"
+        )]
+        fn $fn_name(hosting_config_state: &HostingConfigState) -> StepResult<()> {
+            configure_hosting_state(
+                hosting_config_state,
+                HostingStateOptions {
+                    $($field: $value,)*
+                    ..Default::default()
+                },
+            )
+        }
+    };
 }
 
-#[given("a hosted custom agent configuration")]
-#[expect(
-    clippy::unnecessary_wraps,
-    reason = "rstest-bdd step functions return StepResult for consistency"
-)]
-fn a_hosted_custom_agent_configuration(
-    hosting_config_state: &HostingConfigState,
-) -> StepResult<()> {
-    configure_hosting_state(
-        hosting_config_state,
-        HostingStateOptions {
-            agent_kind: Some(AgentKind::Custom),
-            agent_mode: Some(AgentMode::Acp),
-            agent_command: Some(String::from("opencode")),
-            ..Default::default()
-        },
-    )
-}
+given_hosting_step!(
+    a_host_mounted_custom_agent_configuration,
+    "a host-mounted custom agent configuration",
+    {
+        workspace_source: Some(WorkspaceSource::HostMount),
+        workspace_host_path: Some(Utf8PathBuf::from("/tmp/project")),
+        agent_kind: Some(AgentKind::Custom),
+        agent_mode: Some(AgentMode::CodexAppServer),
+        agent_command: Some(String::from("opencode")),
+    }
+);
 
-#[given("a host-mounted workspace without a host path")]
-#[expect(
-    clippy::unnecessary_wraps,
-    reason = "rstest-bdd step functions return StepResult for consistency"
-)]
-fn a_host_mounted_workspace_without_a_host_path(
-    hosting_config_state: &HostingConfigState,
-) -> StepResult<()> {
-    configure_hosting_state(
-        hosting_config_state,
-        HostingStateOptions {
-            workspace_source: Some(WorkspaceSource::HostMount),
-            agent_kind: Some(AgentKind::Custom),
-            agent_mode: Some(AgentMode::CodexAppServer),
-            agent_command: Some(String::from("opencode")),
-            ..Default::default()
-        },
-    )
-}
+given_hosting_step!(
+    a_hosted_custom_agent_configuration,
+    "a hosted custom agent configuration",
+    {
+        agent_kind: Some(AgentKind::Custom),
+        agent_mode: Some(AgentMode::Acp),
+        agent_command: Some(String::from("opencode")),
+    }
+);
 
-#[given("a custom hosted agent without a command")]
-#[expect(
-    clippy::unnecessary_wraps,
-    reason = "rstest-bdd step functions return StepResult for consistency"
-)]
-fn a_custom_hosted_agent_without_a_command(
-    hosting_config_state: &HostingConfigState,
-) -> StepResult<()> {
-    configure_hosting_state(
-        hosting_config_state,
-        HostingStateOptions {
-            agent_kind: Some(AgentKind::Custom),
-            agent_mode: Some(AgentMode::CodexAppServer),
-            ..Default::default()
-        },
-    )
-}
+given_hosting_step!(
+    a_host_mounted_workspace_without_a_host_path,
+    "a host-mounted workspace without a host path",
+    {
+        workspace_source: Some(WorkspaceSource::HostMount),
+        agent_kind: Some(AgentKind::Custom),
+        agent_mode: Some(AgentMode::CodexAppServer),
+        agent_command: Some(String::from("opencode")),
+    }
+);
+
+given_hosting_step!(
+    a_custom_hosted_agent_without_a_command,
+    "a custom hosted agent without a command",
+    {
+        agent_kind: Some(AgentKind::Custom),
+        agent_mode: Some(AgentMode::CodexAppServer),
+    }
+);
 
 #[when("the configuration is normalized for run intent")]
 fn the_configuration_is_normalized_for_run_intent(

--- a/tests/bdd_hosting_config_helpers.rs
+++ b/tests/bdd_hosting_config_helpers.rs
@@ -12,15 +12,15 @@ use rstest_bdd_macros::{ScenarioState, given, then, when};
 
 type StepResult<T> = Result<T, String>;
 
-#[derive(Default, ScenarioState)]
 /// State shared across hosted configuration scenarios.
+#[derive(Default, ScenarioState)]
 pub struct HostingConfigState {
     config: Slot<AppConfig>,
     error: Slot<String>,
 }
 
-#[fixture]
 /// Fixture providing a fresh hosted configuration state.
+#[fixture]
 pub fn hosting_config_state() -> HostingConfigState {
     HostingConfigState::default()
 }

--- a/tests/bdd_hosting_config_helpers.rs
+++ b/tests/bdd_hosting_config_helpers.rs
@@ -1,0 +1,210 @@
+//! Behavioural step definitions for hosted-era configuration semantics.
+
+use camino::Utf8PathBuf;
+use podbot::config::{AgentKind, AgentMode, AppConfig, CommandIntent, WorkspaceSource};
+use rstest::fixture;
+use rstest_bdd::Slot;
+use rstest_bdd_macros::{ScenarioState, given, then, when};
+
+type StepResult<T> = Result<T, String>;
+
+#[derive(Default, ScenarioState)]
+/// State shared across hosted configuration scenarios.
+pub struct HostingConfigState {
+    config: Slot<AppConfig>,
+    error: Slot<String>,
+}
+
+#[fixture]
+/// Fixture providing a fresh hosted configuration state.
+pub fn hosting_config_state() -> HostingConfigState {
+    HostingConfigState::default()
+}
+
+#[given("the default application configuration")]
+#[expect(
+    clippy::unnecessary_wraps,
+    reason = "rstest-bdd step functions return StepResult for consistency"
+)]
+fn the_default_application_configuration(
+    hosting_config_state: &HostingConfigState,
+) -> StepResult<()> {
+    hosting_config_state.config.set(AppConfig::default());
+    Ok(())
+}
+
+#[given("a host-mounted custom agent configuration")]
+#[expect(
+    clippy::unnecessary_wraps,
+    reason = "rstest-bdd step functions return StepResult for consistency"
+)]
+fn a_host_mounted_custom_agent_configuration(
+    hosting_config_state: &HostingConfigState,
+) -> StepResult<()> {
+    let mut config = AppConfig::default();
+    config.workspace.source = WorkspaceSource::HostMount;
+    config.workspace.host_path = Some(Utf8PathBuf::from("/tmp/project"));
+    config.agent.kind = AgentKind::Custom;
+    config.agent.mode = AgentMode::CodexAppServer;
+    config.agent.command = Some(String::from("opencode"));
+    hosting_config_state.config.set(config);
+    Ok(())
+}
+
+#[given("a hosted custom agent configuration")]
+#[expect(
+    clippy::unnecessary_wraps,
+    reason = "rstest-bdd step functions return StepResult for consistency"
+)]
+fn a_hosted_custom_agent_configuration(
+    hosting_config_state: &HostingConfigState,
+) -> StepResult<()> {
+    let mut config = AppConfig::default();
+    config.agent.kind = AgentKind::Custom;
+    config.agent.mode = AgentMode::Acp;
+    config.agent.command = Some(String::from("opencode"));
+    hosting_config_state.config.set(config);
+    Ok(())
+}
+
+#[given("a host-mounted workspace without a host path")]
+#[expect(
+    clippy::unnecessary_wraps,
+    reason = "rstest-bdd step functions return StepResult for consistency"
+)]
+fn a_host_mounted_workspace_without_a_host_path(
+    hosting_config_state: &HostingConfigState,
+) -> StepResult<()> {
+    let mut config = AppConfig::default();
+    config.workspace.source = WorkspaceSource::HostMount;
+    config.agent.kind = AgentKind::Custom;
+    config.agent.mode = AgentMode::CodexAppServer;
+    config.agent.command = Some(String::from("opencode"));
+    hosting_config_state.config.set(config);
+    Ok(())
+}
+
+#[given("a custom hosted agent without a command")]
+#[expect(
+    clippy::unnecessary_wraps,
+    reason = "rstest-bdd step functions return StepResult for consistency"
+)]
+fn a_custom_hosted_agent_without_a_command(
+    hosting_config_state: &HostingConfigState,
+) -> StepResult<()> {
+    let mut config = AppConfig::default();
+    config.agent.kind = AgentKind::Custom;
+    config.agent.mode = AgentMode::CodexAppServer;
+    hosting_config_state.config.set(config);
+    Ok(())
+}
+
+#[when("the configuration is normalized for run intent")]
+fn the_configuration_is_normalized_for_run_intent(
+    hosting_config_state: &HostingConfigState,
+) -> StepResult<()> {
+    normalize_for_intent(hosting_config_state, CommandIntent::Run)
+}
+
+#[when("the configuration is normalized for host intent")]
+fn the_configuration_is_normalized_for_host_intent(
+    hosting_config_state: &HostingConfigState,
+) -> StepResult<()> {
+    normalize_for_intent(hosting_config_state, CommandIntent::Host)
+}
+
+#[then("the normalized configuration uses github_clone workspace defaults")]
+fn the_normalized_configuration_uses_github_clone_workspace_defaults(
+    hosting_config_state: &HostingConfigState,
+) -> StepResult<()> {
+    let config = get_config(hosting_config_state)?;
+    assert_eq!(config.workspace.source, WorkspaceSource::GithubClone);
+    assert_eq!(config.workspace.base_dir.as_str(), "/work");
+    Ok(())
+}
+
+#[then("the normalized configuration uses podbot agent defaults")]
+fn the_normalized_configuration_uses_podbot_agent_defaults(
+    hosting_config_state: &HostingConfigState,
+) -> StepResult<()> {
+    let config = get_config(hosting_config_state)?;
+    assert_eq!(config.agent.kind, AgentKind::Claude);
+    assert_eq!(config.agent.mode, AgentMode::Podbot);
+    Ok(())
+}
+
+#[then("the workspace container path defaults to /workspace")]
+fn the_workspace_container_path_defaults_to_workspace(
+    hosting_config_state: &HostingConfigState,
+) -> StepResult<()> {
+    let config = get_config(hosting_config_state)?;
+    assert_eq!(config.workspace.container_path, Some("/workspace".into()));
+    Ok(())
+}
+
+#[then("semantic validation fails for agent.mode mentioning podbot host")]
+fn semantic_validation_fails_for_agent_mode_mentioning_podbot_host(
+    hosting_config_state: &HostingConfigState,
+) -> StepResult<()> {
+    assert_invalid_value(hosting_config_state, "agent.mode", "podbot host")
+}
+
+#[then("semantic validation fails for workspace.host_path mentioning host_mount")]
+fn semantic_validation_fails_for_workspace_host_path_mentioning_host_mount(
+    hosting_config_state: &HostingConfigState,
+) -> StepResult<()> {
+    assert_invalid_value(hosting_config_state, "workspace.host_path", "host_mount")
+}
+
+#[then("semantic validation fails for agent.command mentioning requires a non-empty")]
+fn semantic_validation_fails_for_agent_command_mentioning_requires_a_non_empty(
+    hosting_config_state: &HostingConfigState,
+) -> StepResult<()> {
+    assert_invalid_value(
+        hosting_config_state,
+        "agent.command",
+        "requires a non-empty",
+    )
+}
+
+fn normalize_for_intent(
+    hosting_config_state: &HostingConfigState,
+    intent: CommandIntent,
+) -> StepResult<()> {
+    let mut config = get_config(hosting_config_state)?;
+
+    match config.normalize_and_validate(intent) {
+        Ok(()) => hosting_config_state.config.set(config),
+        Err(error) => hosting_config_state.error.set(error.to_string()),
+    }
+
+    Ok(())
+}
+
+fn get_config(hosting_config_state: &HostingConfigState) -> StepResult<AppConfig> {
+    hosting_config_state
+        .config
+        .get()
+        .ok_or_else(|| String::from("config should be set"))
+}
+
+fn assert_invalid_value(
+    hosting_config_state: &HostingConfigState,
+    expected_field: &str,
+    expected_reason: &str,
+) -> StepResult<()> {
+    let error = hosting_config_state
+        .error
+        .get()
+        .ok_or_else(|| String::from("semantic error should be set"))?;
+
+    if !error.contains(expected_field) {
+        return Err(format!(
+            "expected '{error}' to mention field '{expected_field}'"
+        ));
+    }
+    if !error.contains(expected_reason) {
+        return Err(format!("expected '{error}' to mention '{expected_reason}'"));
+    }
+    Ok(())
+}

--- a/tests/bdd_hosting_config_loader.rs
+++ b/tests/bdd_hosting_config_loader.rs
@@ -1,0 +1,36 @@
+//! Behavioural tests for hosted library configuration loading.
+
+mod bdd_hosting_config_loader_helpers;
+
+pub use bdd_hosting_config_loader_helpers::{
+    HostingConfigLoaderState, hosting_config_loader_state,
+};
+use rstest_bdd_macros::scenario;
+
+#[scenario(
+    path = "tests/features/hosting_config_loader.feature",
+    name = "Hosted configuration loads through the library API"
+)]
+fn hosted_configuration_loads_through_the_library_api(
+    hosting_config_loader_state: HostingConfigLoaderState,
+) {
+    let _ = hosting_config_loader_state;
+}
+
+#[scenario(
+    path = "tests/features/hosting_config_loader.feature",
+    name = "Hosting env vars override defaults"
+)]
+fn hosting_env_vars_override_defaults(hosting_config_loader_state: HostingConfigLoaderState) {
+    let _ = hosting_config_loader_state;
+}
+
+#[scenario(
+    path = "tests/features/hosting_config_loader.feature",
+    name = "Run intent rejects hosted library configuration"
+)]
+fn run_intent_rejects_hosted_library_configuration(
+    hosting_config_loader_state: HostingConfigLoaderState,
+) {
+    let _ = hosting_config_loader_state;
+}

--- a/tests/bdd_hosting_config_loader_helpers.rs
+++ b/tests/bdd_hosting_config_loader_helpers.rs
@@ -1,0 +1,233 @@
+//! Behavioural step definitions for hosted library configuration loading.
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
+use camino::Utf8PathBuf;
+use mockable::MockEnv;
+use podbot::config::{CommandIntent, ConfigLoadOptions, WorkspaceSource, load_config_with_env};
+use rstest::fixture;
+use rstest_bdd::Slot;
+use rstest_bdd_macros::{ScenarioState, given, then, when};
+
+type StepResult<T> = Result<T, String>;
+type EnvVars = Arc<Mutex<HashMap<String, String>>>;
+
+#[derive(Default, ScenarioState)]
+/// State shared across hosted library configuration scenarios.
+pub struct HostingConfigLoaderState {
+    env_vars: Slot<EnvVars>,
+    temp_dir: Slot<Arc<tempfile::TempDir>>,
+    options: Slot<ConfigLoadOptions>,
+    config: Slot<podbot::config::AppConfig>,
+    error: Slot<String>,
+}
+
+#[fixture]
+/// Fixture providing a fresh hosting loader state.
+pub fn hosting_config_loader_state() -> HostingConfigLoaderState {
+    let state = HostingConfigLoaderState::default();
+    state.env_vars.set(Arc::new(Mutex::new(HashMap::new())));
+    state.options.set(ConfigLoadOptions {
+        discover_config: false,
+        command_intent: CommandIntent::Host,
+        ..ConfigLoadOptions::default()
+    });
+    state
+}
+
+#[given("a hosting configuration file for a custom codex app server")]
+fn a_hosting_configuration_file_for_a_custom_codex_app_server(
+    hosting_config_loader_state: &HostingConfigLoaderState,
+) -> StepResult<()> {
+    let config_path = write_config_file(
+        hosting_config_loader_state,
+        r#"
+        [workspace]
+        source = "host_mount"
+        host_path = "/tmp/project"
+
+        [agent]
+        kind = "custom"
+        mode = "codex_app_server"
+        command = "opencode"
+    "#,
+    )?;
+    let mut options = get_options(hosting_config_loader_state)?;
+    options.config_path_hint = Some(config_path);
+    hosting_config_loader_state.options.set(options);
+    Ok(())
+}
+
+#[given("hosting environment variables describe an ACP custom agent")]
+fn hosting_environment_variables_describe_an_acp_custom_agent(
+    hosting_config_loader_state: &HostingConfigLoaderState,
+) -> StepResult<()> {
+    set_env_var(
+        hosting_config_loader_state,
+        "PODBOT_WORKSPACE_SOURCE",
+        "host_mount",
+    )?;
+    set_env_var(
+        hosting_config_loader_state,
+        "PODBOT_WORKSPACE_HOST_PATH",
+        "/tmp/project",
+    )?;
+    set_env_var(hosting_config_loader_state, "PODBOT_AGENT_KIND", "custom")?;
+    set_env_var(hosting_config_loader_state, "PODBOT_AGENT_MODE", "acp")?;
+    set_env_var(
+        hosting_config_loader_state,
+        "PODBOT_AGENT_COMMAND",
+        "opencode",
+    )?;
+    Ok(())
+}
+
+#[given("the hosting loader uses run intent")]
+fn the_hosting_loader_uses_run_intent(
+    hosting_config_loader_state: &HostingConfigLoaderState,
+) -> StepResult<()> {
+    let mut options = get_options(hosting_config_loader_state)?;
+    options.command_intent = CommandIntent::Run;
+    hosting_config_loader_state.options.set(options);
+    Ok(())
+}
+
+#[when("the hosting library configuration is loaded")]
+fn the_hosting_library_configuration_is_loaded(
+    hosting_config_loader_state: &HostingConfigLoaderState,
+) -> StepResult<()> {
+    let env = create_mock_env(hosting_config_loader_state)?;
+    let options = get_options(hosting_config_loader_state)?;
+
+    match load_config_with_env(&env, &options) {
+        Ok(config) => hosting_config_loader_state.config.set(config),
+        Err(error) => hosting_config_loader_state.error.set(error.to_string()),
+    }
+
+    Ok(())
+}
+
+#[then("the loaded hosting configuration uses a host-mounted workspace")]
+fn the_loaded_hosting_configuration_uses_a_host_mounted_workspace(
+    hosting_config_loader_state: &HostingConfigLoaderState,
+) -> StepResult<()> {
+    let config = get_loaded_config(hosting_config_loader_state)?;
+    assert_eq!(config.workspace.source, WorkspaceSource::HostMount);
+    Ok(())
+}
+
+#[then("the loaded hosting agent mode is codex_app_server")]
+fn the_loaded_hosting_agent_mode_is_codex_app_server(
+    hosting_config_loader_state: &HostingConfigLoaderState,
+) -> StepResult<()> {
+    assert_agent_mode(hosting_config_loader_state, "codex_app_server")
+}
+
+#[then("the loaded hosting agent mode is acp")]
+fn the_loaded_hosting_agent_mode_is_acp(
+    hosting_config_loader_state: &HostingConfigLoaderState,
+) -> StepResult<()> {
+    assert_agent_mode(hosting_config_loader_state, "acp")
+}
+
+#[then("the loaded hosting workspace container path is /workspace")]
+fn the_loaded_hosting_workspace_container_path_is_workspace(
+    hosting_config_loader_state: &HostingConfigLoaderState,
+) -> StepResult<()> {
+    let config = get_loaded_config(hosting_config_loader_state)?;
+    assert_eq!(config.workspace.container_path, Some("/workspace".into()));
+    Ok(())
+}
+
+#[then("hosting configuration loading fails mentioning podbot host")]
+fn hosting_configuration_loading_fails_mentioning_podbot_host(
+    hosting_config_loader_state: &HostingConfigLoaderState,
+) -> StepResult<()> {
+    let error = hosting_config_loader_state
+        .error
+        .get()
+        .ok_or_else(|| String::from("error should be set"))?;
+    assert!(
+        error.contains("podbot host"),
+        "expected error to mention podbot host, got: {error}"
+    );
+    Ok(())
+}
+
+fn get_env_vars(hosting_config_loader_state: &HostingConfigLoaderState) -> StepResult<EnvVars> {
+    hosting_config_loader_state
+        .env_vars
+        .get()
+        .ok_or_else(|| String::from("env vars should be initialised"))
+}
+
+fn set_env_var(
+    hosting_config_loader_state: &HostingConfigLoaderState,
+    key: &str,
+    value: &str,
+) -> StepResult<()> {
+    let env_vars = get_env_vars(hosting_config_loader_state)?;
+    let mut vars = env_vars
+        .lock()
+        .map_err(|_| String::from("mutex poisoned"))?;
+    vars.insert(String::from(key), String::from(value));
+    Ok(())
+}
+
+fn create_mock_env(hosting_config_loader_state: &HostingConfigLoaderState) -> StepResult<MockEnv> {
+    let env_vars = get_env_vars(hosting_config_loader_state)?;
+    let vars = env_vars
+        .lock()
+        .map_err(|_| String::from("mutex poisoned"))?
+        .clone();
+
+    let mut env = MockEnv::new();
+    env.expect_string()
+        .returning(move |key| vars.get(key).cloned());
+    Ok(env)
+}
+
+fn get_options(
+    hosting_config_loader_state: &HostingConfigLoaderState,
+) -> StepResult<ConfigLoadOptions> {
+    hosting_config_loader_state
+        .options
+        .get()
+        .ok_or_else(|| String::from("options should be set"))
+}
+
+fn write_config_file(
+    hosting_config_loader_state: &HostingConfigLoaderState,
+    content: &str,
+) -> StepResult<Utf8PathBuf> {
+    let temp_dir = tempfile::TempDir::new().map_err(|error| error.to_string())?;
+    let temp_dir_arc = Arc::new(temp_dir);
+    let raw_path = temp_dir_arc.path().join("config.toml");
+    std::fs::write(&raw_path, content).map_err(|error| error.to_string())?;
+    let path = Utf8PathBuf::try_from(raw_path).map_err(|error| error.to_string())?;
+    hosting_config_loader_state.temp_dir.set(temp_dir_arc);
+    Ok(path)
+}
+
+fn get_loaded_config(
+    hosting_config_loader_state: &HostingConfigLoaderState,
+) -> StepResult<podbot::config::AppConfig> {
+    hosting_config_loader_state
+        .config
+        .get()
+        .ok_or_else(|| String::from("config should be set"))
+}
+
+fn assert_agent_mode(
+    hosting_config_loader_state: &HostingConfigLoaderState,
+    expected: &str,
+) -> StepResult<()> {
+    let config = get_loaded_config(hosting_config_loader_state)?;
+    let actual = serde_json::to_string(&config.agent.mode).map_err(|error| error.to_string())?;
+    let expected_json = format!("\"{expected}\"");
+    if actual != expected_json {
+        return Err(format!("expected agent mode {expected_json}, got {actual}"));
+    }
+    Ok(())
+}

--- a/tests/bdd_hosting_config_loader_helpers.rs
+++ b/tests/bdd_hosting_config_loader_helpers.rs
@@ -13,8 +13,8 @@ use rstest_bdd_macros::{ScenarioState, given, then, when};
 type StepResult<T> = Result<T, String>;
 type EnvVars = Arc<Mutex<HashMap<String, String>>>;
 
-#[derive(Default, ScenarioState)]
 /// State shared across hosted library configuration scenarios.
+#[derive(Default, ScenarioState)]
 pub struct HostingConfigLoaderState {
     env_vars: Slot<EnvVars>,
     temp_dir: Slot<Arc<tempfile::TempDir>>,
@@ -23,8 +23,8 @@ pub struct HostingConfigLoaderState {
     error: Slot<String>,
 }
 
-#[fixture]
 /// Fixture providing a fresh hosting loader state.
+#[fixture]
 pub fn hosting_config_loader_state() -> HostingConfigLoaderState {
     let state = HostingConfigLoaderState::default();
     state.env_vars.set(Arc::new(Mutex::new(HashMap::new())));

--- a/tests/features/hosting_config_loader.feature
+++ b/tests/features/hosting_config_loader.feature
@@ -1,0 +1,23 @@
+Feature: Library hosting configuration loader
+
+  Embedders should be able to load hosted configurations through the library
+  API without using Clap types.
+
+  Scenario: Hosted configuration loads through the library API
+    Given a hosting configuration file for a custom codex app server
+    When the hosting library configuration is loaded
+    Then the loaded hosting configuration uses a host-mounted workspace
+    And the loaded hosting agent mode is codex_app_server
+    And the loaded hosting workspace container path is /workspace
+
+  Scenario: Hosting env vars override defaults
+    Given hosting environment variables describe an ACP custom agent
+    When the hosting library configuration is loaded
+    Then the loaded hosting agent mode is acp
+    And the loaded hosting workspace container path is /workspace
+
+  Scenario: Run intent rejects hosted library configuration
+    Given hosting environment variables describe an ACP custom agent
+    And the hosting loader uses run intent
+    When the hosting library configuration is loaded
+    Then hosting configuration loading fails mentioning podbot host

--- a/tests/features/hosting_configuration.feature
+++ b/tests/features/hosting_configuration.feature
@@ -1,0 +1,30 @@
+Feature: Hosting configuration compatibility
+
+  Hosted app-server configurations should load deterministically and fail with
+  actionable semantic errors when the schema is used incorrectly.
+
+  Scenario: Legacy interactive configuration remains valid
+    Given the default application configuration
+    When the configuration is normalized for run intent
+    Then the normalized configuration uses github_clone workspace defaults
+    And the normalized configuration uses podbot agent defaults
+
+  Scenario: Host-mounted workspace gains a default container path
+    Given a host-mounted custom agent configuration
+    When the configuration is normalized for host intent
+    Then the workspace container path defaults to /workspace
+
+  Scenario: Run intent rejects hosted modes
+    Given a hosted custom agent configuration
+    When the configuration is normalized for run intent
+    Then semantic validation fails for agent.mode mentioning podbot host
+
+  Scenario: Host mount requires an explicit host path
+    Given a host-mounted workspace without a host path
+    When the configuration is normalized for host intent
+    Then semantic validation fails for workspace.host_path mentioning host_mount
+
+  Scenario: Custom agents require an explicit command
+    Given a custom hosted agent without a command
+    When the configuration is normalized for host intent
+    Then semantic validation fails for agent.command mentioning requires a non-empty

--- a/tests/load_config_image_resolution.rs
+++ b/tests/load_config_image_resolution.rs
@@ -10,7 +10,9 @@ use std::io::Write;
 use crate::test_support::env_with;
 use camino::Utf8PathBuf;
 use mockable::MockEnv;
-use podbot::config::{AppConfig, ConfigLoadOptions, ConfigOverrides, load_config_with_env};
+use podbot::config::{
+    AppConfig, CommandIntent, ConfigLoadOptions, ConfigOverrides, load_config_with_env,
+};
 use podbot::engine::CreateContainerRequest;
 use podbot::error::{ConfigError, PodbotError};
 use rstest::rstest;
@@ -49,7 +51,10 @@ fn load_config_for_image_layers(
         overrides: ConfigOverrides {
             engine_socket: None,
             image: overrides_image.map(str::to_owned),
+            agent_kind: None,
+            agent_mode: None,
         },
+        command_intent: CommandIntent::Any,
     };
 
     load_config_with_env(env, &options).expect("load_config should succeed for image layer test")

--- a/tests/load_config_integration.rs
+++ b/tests/load_config_integration.rs
@@ -11,7 +11,9 @@ use std::io::Write;
 
 use crate::test_support::env_with;
 use camino::Utf8PathBuf;
-use podbot::config::{ConfigLoadOptions, ConfigOverrides, SelinuxLabelMode, load_config_with_env};
+use podbot::config::{
+    CommandIntent, ConfigLoadOptions, ConfigOverrides, SelinuxLabelMode, load_config_with_env,
+};
 use rstest::rstest;
 use tempfile::NamedTempFile;
 
@@ -138,7 +140,10 @@ fn load_config_overrides_take_precedence_over_config_file() {
         overrides: ConfigOverrides {
             engine_socket: Some(String::from("unix:///from/overrides.sock")),
             image: None,
+            agent_kind: None,
+            agent_mode: None,
         },
+        command_intent: CommandIntent::Any,
     };
     let config = load_config_with_env(&env, &options).expect("load_config should succeed");
 

--- a/tests/load_hosting_config_integration.rs
+++ b/tests/load_hosting_config_integration.rs
@@ -65,10 +65,10 @@ fn load_config_applies_env_overrides_for_hosting_fields() {
         ("PODBOT_AGENT_KIND", "custom"),
         ("PODBOT_AGENT_MODE", "acp"),
         ("PODBOT_AGENT_COMMAND", "opencode"),
-        ("PODBOT_AGENT_ARGS", "serve,--json"),
+        ("PODBOT_AGENT_ARGS", " serve , --json "),
         (
             "PODBOT_AGENT_ENV_ALLOWLIST",
-            "OPENAI_API_KEY,ANTHROPIC_API_KEY",
+            ",OPENAI_API_KEY,,ANTHROPIC_API_KEY,",
         ),
     ]);
 
@@ -140,6 +140,43 @@ fn load_config_rejects_custom_agent_without_command() {
         .expect_err("custom hosted agent should require a command");
 
     assert_invalid_value(error, "agent.command", "requires a non-empty");
+}
+
+#[rstest]
+fn hosted_agent_kind_and_mode_follow_override_env_file_precedence() {
+    let config_file = temp_config_file(
+        r#"
+        [agent]
+        kind = "claude"
+        mode = "podbot"
+    "#,
+    )
+    .expect("temp config file creation should succeed");
+    let config_path = Utf8PathBuf::try_from(config_file.path().to_path_buf())
+        .expect("path should be valid UTF-8");
+    let env = env_with(&[
+        ("PODBOT_AGENT_KIND", "codex"),
+        ("PODBOT_AGENT_MODE", "acp"),
+        ("PODBOT_AGENT_COMMAND", "opencode"),
+    ]);
+    let options = ConfigLoadOptions {
+        config_path_hint: Some(config_path),
+        discover_config: false,
+        command_intent: CommandIntent::Host,
+        overrides: ConfigOverrides {
+            engine_socket: None,
+            image: None,
+            agent_kind: Some(AgentKind::Custom),
+            agent_mode: Some(AgentMode::CodexAppServer),
+        },
+    };
+
+    let config = load_config_with_env(&env, &options)
+        .expect("override values should take precedence in hosted config");
+
+    assert_eq!(config.agent.kind, AgentKind::Custom);
+    assert_eq!(config.agent.mode, AgentMode::CodexAppServer);
+    assert_eq!(config.agent.command.as_deref(), Some("opencode"));
 }
 
 fn assert_invalid_value(error: PodbotError, expected_field: &str, expected_reason: &str) {

--- a/tests/load_hosting_config_integration.rs
+++ b/tests/load_hosting_config_integration.rs
@@ -1,0 +1,156 @@
+//! Integration tests for hosted-era configuration loading.
+
+mod test_support;
+
+use std::io::Write;
+
+use crate::test_support::env_with;
+use camino::Utf8PathBuf;
+use podbot::config::{
+    AgentKind, AgentMode, CommandIntent, ConfigLoadOptions, ConfigOverrides, WorkspaceSource,
+    load_config_with_env,
+};
+use podbot::error::{ConfigError, PodbotError};
+use rstest::rstest;
+use tempfile::NamedTempFile;
+
+fn temp_config_file(content: &str) -> std::io::Result<NamedTempFile> {
+    let mut file = NamedTempFile::new()?;
+    file.write_all(content.as_bytes())?;
+    Ok(file)
+}
+
+#[rstest]
+fn load_config_normalizes_host_mount_defaults() {
+    let config_file = temp_config_file(
+        r#"
+        [workspace]
+        source = "host_mount"
+        host_path = "/tmp/project"
+
+        [agent]
+        kind = "custom"
+        mode = "codex_app_server"
+        command = "opencode"
+    "#,
+    )
+    .expect("temp config file creation should succeed");
+    let config_path = Utf8PathBuf::try_from(config_file.path().to_path_buf())
+        .expect("path should be valid UTF-8");
+    let env = env_with(&[]);
+
+    let config = load_config_with_env(
+        &env,
+        &ConfigLoadOptions {
+            config_path_hint: Some(config_path),
+            discover_config: false,
+            command_intent: CommandIntent::Host,
+            ..ConfigLoadOptions::default()
+        },
+    )
+    .expect("host config should load");
+
+    assert_eq!(config.workspace.source, WorkspaceSource::HostMount);
+    assert_eq!(config.workspace.host_path, Some("/tmp/project".into()));
+    assert_eq!(config.workspace.container_path, Some("/workspace".into()));
+    assert_eq!(config.agent.kind, AgentKind::Custom);
+    assert_eq!(config.agent.mode, AgentMode::CodexAppServer);
+}
+
+#[rstest]
+fn load_config_applies_env_overrides_for_hosting_fields() {
+    let env = env_with(&[
+        ("PODBOT_WORKSPACE_SOURCE", "host_mount"),
+        ("PODBOT_WORKSPACE_HOST_PATH", "/tmp/project"),
+        ("PODBOT_AGENT_KIND", "custom"),
+        ("PODBOT_AGENT_MODE", "acp"),
+        ("PODBOT_AGENT_COMMAND", "opencode"),
+        ("PODBOT_AGENT_ARGS", "serve,--json"),
+        (
+            "PODBOT_AGENT_ENV_ALLOWLIST",
+            "OPENAI_API_KEY,ANTHROPIC_API_KEY",
+        ),
+    ]);
+
+    let config = load_config_with_env(
+        &env,
+        &ConfigLoadOptions {
+            discover_config: false,
+            command_intent: CommandIntent::Host,
+            ..ConfigLoadOptions::default()
+        },
+    )
+    .expect("hosting env vars should load");
+
+    assert_eq!(config.workspace.source, WorkspaceSource::HostMount);
+    assert_eq!(config.workspace.host_path, Some("/tmp/project".into()));
+    assert_eq!(config.workspace.container_path, Some("/workspace".into()));
+    assert_eq!(config.agent.kind, AgentKind::Custom);
+    assert_eq!(config.agent.mode, AgentMode::Acp);
+    assert_eq!(config.agent.command.as_deref(), Some("opencode"));
+    assert_eq!(
+        config.agent.args,
+        vec![String::from("serve"), String::from("--json")]
+    );
+    assert_eq!(
+        config.agent.env_allowlist,
+        vec![
+            String::from("OPENAI_API_KEY"),
+            String::from("ANTHROPIC_API_KEY"),
+        ]
+    );
+}
+
+#[rstest]
+fn load_config_rejects_hosted_mode_for_run_intent() {
+    let env = env_with(&[
+        ("PODBOT_AGENT_KIND", "custom"),
+        ("PODBOT_AGENT_MODE", "acp"),
+        ("PODBOT_AGENT_COMMAND", "opencode"),
+    ]);
+
+    let error = load_config_with_env(
+        &env,
+        &ConfigLoadOptions {
+            discover_config: false,
+            command_intent: CommandIntent::Run,
+            ..ConfigLoadOptions::default()
+        },
+    )
+    .expect_err("run intent should reject hosted modes");
+
+    assert_invalid_value(error, "agent.mode", "hosted modes require `podbot host`");
+}
+
+#[rstest]
+fn load_config_rejects_custom_agent_without_command() {
+    let options = ConfigLoadOptions {
+        discover_config: false,
+        command_intent: CommandIntent::Host,
+        overrides: ConfigOverrides {
+            engine_socket: None,
+            image: None,
+            agent_kind: Some(AgentKind::Custom),
+            agent_mode: Some(AgentMode::CodexAppServer),
+        },
+        ..ConfigLoadOptions::default()
+    };
+
+    let error = load_config_with_env(&env_with(&[]), &options)
+        .expect_err("custom hosted agent should require a command");
+
+    assert_invalid_value(error, "agent.command", "requires a non-empty");
+}
+
+fn assert_invalid_value(error: PodbotError, expected_field: &str, expected_reason: &str) {
+    match error {
+        PodbotError::Config(ConfigError::InvalidValue { field, reason }) => {
+            assert_eq!(field, expected_field);
+            assert!(
+                reason.contains(expected_reason),
+                "expected '{reason}' to mention '{expected_reason}'"
+            );
+        }
+        other => panic!("expected ConfigError::InvalidValue, got {other:?}"),
+    }
+}


### PR DESCRIPTION
## Summary
- Implemented Step 1.4: Hosting schema migration across codebase, loader normalization, host CLI scaffolding, MCP hosting defaults, and comprehensive tests. ExecPlan doc remains a living planning document but the implementation is complete.
- Status: COMPLETE
- This PR includes code changes in addition to documentation updates.
- Formatting improvements to eyre report doc (docs/execplans/1-2-2-eyre-report.md) were preserved where applicable.

## Changes
- Documentation
  - New file: docs/execplans/1-4-1-hosting-schema-migration.md
  - Updated docs: docs/podbot-design.md (hosting-era fields and validation behavior)
  - Updated docs: docs/podbot-roadmap.md to reflect Step 1.4 completion
  - Updated docs: docs/users-guide.md with hosting-related configuration keys and host-subcommand behavior
- Core config code
  - New modules under src/config:
    - src/config/agent.rs (AgentKind, AgentMode, AgentConfig)
    - src/config/workspace.rs (WorkspaceSource, WorkspaceConfig, defaults)
    - src/config/hosting.rs (MCP hosting defaults and config)
    - src/config/validation.rs (semantic normalization and legality checks; CommandIntent)
  - Updated src/config/mod.rs to expose new types/defaults
  - Updated src/config/env_vars.rs to map hosting-era environment variables (including lists)
  - Updated loader/overrides logic to support hosting overrides and command intent validation
  - src/config/load_options.rs extended with agent_kind/agent_mode overrides and CommandIntent
- CLI and runtime wiring
  - src/cli/mod.rs updated to support a Host subcommand and extended mapping to library overrides; added CommandIntent handling
  - src/main.rs updated to route hosting flow (host) and reflect hosted mode in logs
- Tests and test helpers
  - Added hosting tests: hosting_layer_precedence_tests.rs, hosting_types_tests.rs, semantic_validation_tests.rs
  - Expanded test helpers and BDD scaffolding (rstest, rstest-bdd) to cover hosting scenarios
  - New tests and features for hosting configurations and loader behavior (BDD style) under tests/features and tests/bdd_*
- Artefacts and Notes
  - ExecPlan living document updated in place; new hosting docs mirror implementation progress
  - Several tests cover: type-level hosting defaults, env overrides, normalization, and semantic validation

## Rationale and acceptance criteria
- This delivers hosting-era support with a deterministic, centralized normalization/validation flow that coexists with legacy configurations.
- Acceptance criteria addressed:
  - Legacy configs load unchanged; hosting-era configs load with new defaults
  - Invalid combos yield actionable semantic errors
  - Unit tests cover hosting defaults and normalization; behavioural tests cover hosting scenarios
  - Documentation updated to reflect migration decisions and user-visible behavior
  - All quality gates (fmt, lint, test) pass for hosting changes

## Interfaces and dependencies
- Introduces new config modules: agent, workspace, hosting, validation
- Extends env var mapping to include hosting-era keys (including lists)
- Adds host subcommand scaffold to CLI and routing in main
- No new external dependencies introduced beyond existing rstest/rstest-bdd tooling already pinned

## artefacts and references
- New: docs/execplans/1-4-1-hosting-schema-migration.md
- Updated: docs/podbot-design.md, docs/podbot-roadmap.md, docs/users-guide.md
- Updated: src/config/mod.rs, src/config/load_options.rs, src/config/loader.rs
- Added: src/config/agent.rs, src/config/workspace.rs, src/config/hosting.rs, src/config/validation.rs
- Added: tests/src/config/hosting_layer_precedence_tests.rs, hosting_types_tests.rs, semantic_validation_tests.rs
- Added: tests/features/hosting_configuration.feature, tests/features/hosting_config_loader.feature, tests/bdd_hosting_config.rs and related helpers

## artefacts and references
- New: docs/execplans/1-4-1-hosting-schema-migration.md
- Updated: docs/podbot-design.md, docs/podbot-roadmap.md, docs/users-guide.md
- Updated: src/config/mod.rs, src/config/load_options.rs, src/config/loader.rs
- Added: src/config/agent.rs, src/config/workspace.rs, src/config/hosting.rs, src/config/validation.rs
- Added: tests/src/config/hosting_layer_precedence_tests.rs, hosting_types_tests.rs, semantic_validation_tests.rs
- Added: tests/features/hosting_configuration.feature, tests/features/hosting_config_loader.feature, tests/bdd_hosting_config.rs and related helpers

## Task link
- Task: https://www.devboxer.com/task/6044fbbb-351f-4e6a-8d1b-6fd826777763

📎 **Task**: https://www.devboxer.com/task/4e5db679-edd6-4bb4-a130-fe797100ede4