### PR TITLE
Plan and Expand Git Identity Configuration (engine/API/tests/docs)

### DIFF
--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -463,3 +463,100 @@ Documentation uses British English with Oxford spelling (`en-GB-oxendict`):
 - Capitalize proper nouns: Markdown, GitHub, Rust
 
 The words "outwith" and "caveat" are acceptable.
+
+## 14. Git identity configuration subsystem
+
+The `git_identity` module (`src/engine/connection/git_identity/`) propagates
+host Git identity (`user.name`, `user.email`) into a running container via
+`git config --global`. It is exposed through the `engine/connection` module
+and orchestrated by `src/api/configure_git_identity.rs`.
+
+### 14.1. Module layout
+
+```plaintext
+src/engine/connection/git_identity/
++-- mod.rs                   # Re-exports, git_identity_exec_failed helper
++-- host_reader.rs           # HostCommandRunner trait, SystemCommandRunner,
+|                            #   HostGitIdentity, read_host_git_identity
++-- container_configurator.rs# configure_git_identity, GitIdentityResult,
+|                            #   IdentityCompleteness classifier
++-- tests.rs                 # Unit tests for host_reader
+```
+
+### 14.2. Key types and traits
+
+- **`HostCommandRunner`**: trait abstracting `std::process::Command` execution
+  so tests can inject a mock runner without spawning a real process. Implement
+  `run_command(&self, program: &str, args: &[&str]) -> io::Result<Output>`.
+- **`SystemCommandRunner`**: production implementation that delegates to
+  `std::process::Command`.
+- **`HostGitIdentity`**: struct holding `name: Option<String>` and
+  `email: Option<String>` read from the host.
+- **`GitIdentityResult`**: enum representing the configuration outcome:
+  - `Configured { name, email }` — both fields set in the container.
+  - `Partial { name, email, warnings }` — one field set; `warnings` names
+    the missing field.
+  - `NoneConfigured { warnings }` — neither field present on the host;
+    container Git config unchanged.
+- **`GitIdentityParams`**: Application Programming Interface (API) layer
+  struct bundling the container exec client, host command runner, container
+  identifier (ID), and Tokio runtime handle for the orchestration entry
+  point.
+
+### 14.3. Execution flow
+
+For screen readers: The following flowchart shows how
+`configure_container_git_identity` reads host identity, classifies
+completeness, and delegates to the appropriate configuration path.
+
+```mermaid
+flowchart TD
+    A["configure_container_git_identity(params)"] --> B["read_host_git_identity(host_runner)"]
+    B --> C["classify_identity(identity)"]
+    C -->|Complete| D["configure_complete_identity"]
+    C -->|Partial| E["configure_partial_identity"]
+    C -->|None| F["GitIdentityResult::NoneConfigured"]
+    D --> G["set_git_config user.name"]
+    D --> H["set_git_config user.email"]
+    E --> I["set_git_config for present fields only"]
+    G & H --> J["GitIdentityResult::Configured"]
+    I --> K["GitIdentityResult::Partial"]
+```
+
+_Figure 2: Git identity configuration execution flow._
+
+### 14.4. Dependency injection (DI) pattern
+
+Following the project's dependency injection (DI) convention (see
+[reliable-testing-in-rust-via-dependency-injection.md](reliable-testing-in-rust-via-dependency-injection.md)),
+all external process calls are abstracted behind `HostCommandRunner`. The
+`configure_git_identity` function accepts a `ContainerExecClient` for the
+same reason. Neither function spawns processes or calls the container engine
+directly; callers inject the concrete implementations.
+
+### 14.5. Error handling
+
+- Missing host fields are not errors; they produce `Partial` or
+  `NoneConfigured` results with warning strings drawn from the
+  `MISSING_NAME_WARNING` and `MISSING_EMAIL_WARNING` constants in
+  `container_configurator.rs`.
+- Container-side failures (non-zero `git config` exit code) map to
+  `PodbotError::Container(ContainerError::ExecFailed { container_id,
+  message })` via the `git_identity_exec_failed` helper in `mod.rs`.
+- Host-side input/output (IO) failures (e.g. `git` not installed) are
+  silently treated as `None` for the affected field; only a `Partial` or
+  `NoneConfigured` result is returned.
+
+### 14.6. Adding a new identity field
+
+1. Add the field to `HostGitIdentity` in `host_reader.rs`.
+2. Update `read_host_git_identity` to populate the new field.
+3. Add the field to `GitIdentityResult` variants as needed.
+4. Update `classify_identity` and `configure_complete_identity` /
+   `configure_partial_identity` in `container_configurator.rs`.
+5. Add a `MISSING_<FIELD>_WARNING` constant and include it in the warning
+   vectors for `Partial` and `NoneConfigured` paths.
+6. Add a `#[case]` row to `read_identity_with_ok_responses` in `tests.rs`.
+7. Add Behaviour-Driven Development (BDD) scenarios in
+   `tests/features/git_identity.feature` and matching step definitions.
+8. Update this section and `docs/users-guide.md`.

--- a/docs/execplans/4-1-1-git-identity-configuration.md
+++ b/docs/execplans/4-1-1-git-identity-configuration.md
@@ -5,7 +5,7 @@ This ExecPlan (execution plan) is a living document. The sections
 `Decision log`, and `Outcomes and retrospective` must be kept up to date as
 work proceeds.
 
-Status: IN-PROGRESS
+Status: COMPLETED
 
 ## Purpose and big picture
 
@@ -97,18 +97,18 @@ escalation, not workarounds.
 
 ## Progress
 
-- [ ] Stage A: Create `src/engine/connection/git_identity/` module with
+- [x] Stage A: Create `src/engine/connection/git_identity/` module with
   host reader trait, container configurator, and unit tests.
-- [ ] Stage A: Gate check (`make check-fmt`, `make lint`, `make test`).
-- [ ] Stage B: Create API orchestration function in `src/api/`.
-- [ ] Stage B: Gate check.
-- [ ] Stage C: Create BDD feature file, test scaffolding, steps,
+- [x] Stage A: Gate check (`make check-fmt`, `make lint`, `make test`).
+- [x] Stage B: Create API orchestration function in `src/api/`.
+- [x] Stage B: Gate check.
+- [x] Stage C: Create BDD feature file, test scaffolding, steps,
   assertions.
-- [ ] Stage C: Gate check.
-- [ ] Stage D: Update design doc, users' guide, roadmap; save execution
+- [x] Stage C: Gate check.
+- [x] Stage D: Update design doc, users' guide, roadmap; save execution
   plan.
-- [ ] Stage D: Gate check (full stack including markdownlint).
-- [ ] Stage E: Final verification and commit.
+- [x] Stage D: Gate check (full stack including markdownlint).
+- [x] Stage E: Final verification and commit.
 
 ## Surprises and discoveries
 
@@ -118,9 +118,9 @@ escalation, not workarounds.
 
 - Decision: abstract host Git config reading behind a
   `HostCommandRunner` trait rather than calling `std::process::Command`
-  directly. Rationale: follows the project's DI convention
-  (`docs/reliable-testing-in-rust-via-dependency-injection.md`). Tests
-  can inject a mock that returns configurable identity values without
+  directly. Rationale: follows the project's dependency injection (DI)
+  convention (`docs/reliable-testing-in-rust-via-dependency-injection.md`).
+  Tests can inject a mock that returns configurable identity values without
   requiring `git` to be installed. The trait has a single method
   `run_command(&self, program: &str, args: &[&str]) -> io::Result<Output>`
   with a production implementation wrapping `std::process::Command`.
@@ -156,8 +156,9 @@ escalation, not workarounds.
 ## Context and orientation
 
 Podbot is a Rust application that runs AI coding agents (Claude Code,
-Codex) in sandboxed containers. It provides two delivery surfaces: a CLI
-binary and a Rust library. The project lives at `/home/user/project`.
+Codex) in sandboxed containers. It provides two delivery surfaces: a
+command-line interface (CLI) binary and a Rust library. The project lives at
+`/home/user/project`.
 
 The design document (`docs/podbot-design.md`, line 100) specifies:
 
@@ -694,7 +695,7 @@ pub fn configure_container_git_identity<
     C: ContainerExecClient,
     R: HostCommandRunner,
 >(
-    params: GitIdentityParams<'_, C, R>,
+    params: &GitIdentityParams<'_, C, R>,
 ) -> PodbotResult<GitIdentityResult> {
     let identity = read_host_git_identity(params.host_runner);
     engine_configure(
@@ -907,7 +908,7 @@ In `src/api/configure_git_identity.rs`:
 pub struct GitIdentityParams<'a, C, R> { ... }
 
 pub fn configure_container_git_identity<C, R>(
-    params: GitIdentityParams<'_, C, R>,
+    params: &GitIdentityParams<'_, C, R>,
 ) -> PodbotResult<GitIdentityResult>;
 ```
 

--- a/docs/execplans/4-1-1-git-identity-configuration.md
+++ b/docs/execplans/4-1-1-git-identity-configuration.md
@@ -1,0 +1,1010 @@
+# Step 4.1.1: Configure Git identity within the container
+
+This ExecPlan (execution plan) is a living document. The sections
+`Constraints`, `Tolerances`, `Risks`, `Progress`, `Surprises and discoveries`,
+`Decision log`, and `Outcomes and retrospective` must be kept up to date as
+work proceeds.
+
+Status: IN-PROGRESS
+
+## Purpose and big picture
+
+Complete roadmap Step 4.1 ("Git identity configuration") by reading
+`user.name` and `user.email` from the host Git configuration and executing
+`git config --global` within the container to propagate that identity.
+
+After this change, the container lifecycle will support a deterministic
+Git identity configuration step that:
+
+- reads `user.name` from the host via `git config --get user.name`;
+- reads `user.email` from the host via `git config --get user.email`;
+- executes `git config --global user.name <value>` in the container;
+- executes `git config --global user.email <value>` in the container;
+- warns but does not fail when either identity field is missing on the
+  host.
+
+Observable success: `make check-fmt && make lint && make test` all pass.
+Git identity configuration is testable in isolation with mock host
+command runners and mock container exec clients. Missing identity on the
+host produces a warning-level result rather than a hard error. This is
+Step 4.1 of Phase 4 in the roadmap (`docs/podbot-roadmap.md`).
+
+Required documentation outcomes:
+
+- record design decisions in `docs/podbot-design.md`;
+- update user-visible behaviour in `docs/users-guide.md`;
+- mark Step 4.1 roadmap tasks as done in `docs/podbot-roadmap.md`.
+
+## Constraints
+
+Hard invariants that must hold throughout implementation. Violation requires
+escalation, not workarounds.
+
+- Files must be fewer than 400 lines each.
+- Every module must begin with a `//!` module-level doc comment.
+- en-GB-oxendict spelling ("-ize" / "-yse" / "-our") in all comments and
+  documentation.
+- No `unwrap()` or `expect()` in production code (clippy denies
+  `unwrap_used`, `expect_used`).
+- No `println!` or `eprintln!` in library code (clippy denies
+  `print_stdout`, `print_stderr`).
+- Library functions must not depend on clap types.
+- Library functions must not call `std::process::exit`.
+- Library functions return `podbot::error::Result<T>`.
+- Existing public API signatures in `podbot::engine` and `podbot::config`
+  must not change.
+- No new external crate dependencies may be added.
+- `rstest` for unit tests; `rstest-bdd` v0.5.0 for behavioural tests.
+- BDD step function parameter names must match fixture names exactly.
+- BDD feature files must use unquoted text for `{param}` captures.
+- BDD tests must use `StepResult<T> = Result<T, String>` pattern (no
+  `expect`/`panic`).
+- `make check-fmt`, `make lint`, `make test` must pass before any commit.
+- Commit messages use imperative mood; atomic commits; one logical unit
+  per commit.
+
+## Tolerances (exception triggers)
+
+- **Scope**: if implementation requires changes to more than 15 files or
+  600 net lines of code, stop and escalate.
+- **Interface**: if any existing public API signature in `podbot::engine`
+  or `podbot::config` must change, stop and escalate.
+- **Dependencies**: if a new external crate dependency is required, stop
+  and escalate.
+- **Iterations**: if tests still fail after 3 focused fix attempts on a
+  single issue, stop and escalate.
+- **Ambiguity**: if multiple valid interpretations exist for host command
+  execution, stop and present options.
+
+## Risks
+
+- Risk: host `git` binary may not be installed or may not have identity
+  configured. Severity: medium. Likelihood: medium. Mitigation: treat
+  missing identity as a warning (`GitIdentityResult::Partial` or
+  `::NoneConfigured`), not a hard error. Log the missing fields and
+  continue.
+
+- Risk: shelling out to `git config` from the host introduces a
+  dependency on host tooling. Severity: low. Likelihood: low. Mitigation:
+  abstract host command execution behind a trait (`HostCommandRunner`)
+  that can be mocked in tests. Production implementation uses
+  `std::process::Command`.
+
+- Risk: container exec for `git config --global` could fail if the
+  container image does not have `git` installed. Severity: medium.
+  Likelihood: low. Mitigation: propagate the exec error; the operator
+  must ensure the container image includes `git`.
+
+## Progress
+
+- [ ] Stage A: Create `src/engine/connection/git_identity/` module with
+  host reader trait, container configurator, and unit tests.
+- [ ] Stage A: Gate check (`make check-fmt`, `make lint`, `make test`).
+- [ ] Stage B: Create API orchestration function in `src/api/`.
+- [ ] Stage B: Gate check.
+- [ ] Stage C: Create BDD feature file, test scaffolding, steps,
+  assertions.
+- [ ] Stage C: Gate check.
+- [ ] Stage D: Update design doc, users' guide, roadmap; save execution
+  plan.
+- [ ] Stage D: Gate check (full stack including markdownlint).
+- [ ] Stage E: Final verification and commit.
+
+## Surprises and discoveries
+
+(To be filled in during implementation.)
+
+## Decision log
+
+- Decision: abstract host Git config reading behind a
+  `HostCommandRunner` trait rather than calling `std::process::Command`
+  directly. Rationale: follows the project's DI convention
+  (`docs/reliable-testing-in-rust-via-dependency-injection.md`). Tests
+  can inject a mock that returns configurable identity values without
+  requiring `git` to be installed. The trait has a single method
+  `run_command(&self, program: &str, args: &[&str]) -> io::Result<Output>`
+  with a production implementation wrapping `std::process::Command`.
+
+- Decision: place the engine-level Git identity module at
+  `src/engine/connection/git_identity/mod.rs`, following the pattern
+  established by `upload_credentials/`, `create_container/`, and `exec/`.
+  Rationale: Git identity configuration uses the same
+  `ContainerExecClient` trait seam to execute commands in the container,
+  making it a peer of the existing connection submodules.
+
+- Decision: return a `GitIdentityResult` enum with three variants:
+  `Configured { name, email }`, `Partial { name, email, warnings }`, and
+  `NoneConfigured { warnings }`. Rationale: the roadmap explicitly states
+  missing identity should produce a warning rather than failure. Callers
+  can inspect the result to decide how to surface warnings.
+
+- Decision: Git identity configuration does not add new config fields to
+  `AppConfig`. Rationale: the identity is read dynamically from the host
+  `git config` at runtime, not from podbot's own configuration. This
+  avoids configuration sprawl and follows the design doc which says
+  "reading from the host".
+
+- Decision: use `ExecMode::Detached` for `git config --global` commands
+  within the container. Rationale: these are non-interactive commands
+  that do not need stdin/stdout streaming. Detached mode is simpler and
+  avoids the attached-session lifecycle.
+
+## Outcomes and retrospective
+
+(To be filled in after implementation.)
+
+## Context and orientation
+
+Podbot is a Rust application that runs AI coding agents (Claude Code,
+Codex) in sandboxed containers. It provides two delivery surfaces: a CLI
+binary and a Rust library. The project lives at `/home/user/project`.
+
+The design document (`docs/podbot-design.md`, line 100) specifies:
+
+> **Configure Git identity** by reading `user.name` and `user.email`
+> from the host and executing `git config --global` within the container.
+
+This is step 3 in the container lifecycle, after credential injection
+(step 2) and before GitHub token creation (step 4).
+
+Key files:
+
+- `src/engine/connection/mod.rs` -- connection module, re-exports traits
+- `src/engine/connection/exec/mod.rs` -- `ContainerExecClient` trait,
+  `ExecRequest`, `ExecMode::Detached`
+- `src/engine/connection/upload_credentials/mod.rs` -- pattern reference
+  for new connection submodules
+- `src/engine/mod.rs` -- `pub use` re-exports
+- `src/api/mod.rs` -- orchestration API, `CommandOutcome`
+- `src/api/exec.rs` -- `ExecParams`, `exec()`
+- `src/error.rs` -- `ContainerError::ExecFailed`, `PodbotError`
+- `src/main.rs` -- CLI adapter, `run_agent_cli` stub
+
+Existing patterns to follow:
+
+- **Trait seam for DI**: `ContainerExecClient` for container commands;
+  `ContainerUploader` for archive upload; `ContainerCreator` for
+  container creation. Each trait has a `Docker` impl and a `mock!` for
+  testing.
+- **Module structure**: `src/engine/connection/<feature>/mod.rs` with
+  submodules for internals and `tests/`.
+- **BDD tests**: `tests/bdd_<name>.rs` + `tests/bdd_<name>_helpers/` +
+  `tests/features/<name>.feature`.
+- **Error handling**: `thiserror` enums in library; `eyre` at CLI
+  boundary. Use `ContainerError::ExecFailed` for git config exec
+  failures.
+
+## Plan of work
+
+### Stage A: Engine-level Git identity module
+
+Create the engine submodule that handles both host-side Git config
+reading and container-side Git config setting.
+
+#### A.1: Create `src/engine/connection/git_identity/host_reader.rs`
+
+This file defines the trait for running commands on the host and the
+function to read Git identity from the host.
+
+```rust
+//! Host-side Git identity reading.
+//!
+//! Reads `user.name` and `user.email` from the host Git configuration
+//! by running `git config --get` commands. The command runner is
+//! injected for testability.
+
+use std::io;
+use std::process::Output;
+
+/// Runs a command on the host and returns its output.
+///
+/// This trait abstracts host command execution so tests can inject
+/// mock responses without requiring a real `git` binary.
+pub trait HostCommandRunner {
+    /// Execute `program` with `args` and return the captured output.
+    ///
+    /// # Errors
+    ///
+    /// Returns an I/O error if the command cannot be spawned.
+    fn run_command(
+        &self,
+        program: &str,
+        args: &[&str],
+    ) -> io::Result<Output>;
+}
+
+/// Production implementation using `std::process::Command`.
+pub struct SystemCommandRunner;
+
+impl HostCommandRunner for SystemCommandRunner {
+    fn run_command(
+        &self,
+        program: &str,
+        args: &[&str],
+    ) -> io::Result<Output> {
+        std::process::Command::new(program).args(args).output()
+    }
+}
+
+/// Identity fields read from the host Git configuration.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HostGitIdentity {
+    /// `user.name` value, if configured on the host.
+    pub name: Option<String>,
+    /// `user.email` value, if configured on the host.
+    pub email: Option<String>,
+}
+
+/// Read Git `user.name` and `user.email` from the host.
+///
+/// Returns `None` values for fields that are not configured rather
+/// than failing. The caller decides how to handle missing fields.
+pub fn read_host_git_identity(
+    runner: &impl HostCommandRunner,
+) -> HostGitIdentity {
+    HostGitIdentity {
+        name: read_git_config_value(runner, "user.name"),
+        email: read_git_config_value(runner, "user.email"),
+    }
+}
+
+fn read_git_config_value(
+    runner: &impl HostCommandRunner,
+    key: &str,
+) -> Option<String> {
+    let output = runner
+        .run_command("git", &["config", "--get", key])
+        .ok()?;
+
+    if !output.status.success() {
+        return None;
+    }
+
+    let value = String::from_utf8_lossy(&output.stdout)
+        .trim()
+        .to_owned();
+
+    if value.is_empty() { None } else { Some(value) }
+}
+```
+
+#### A.2: Create `src/engine/connection/git_identity/container_configurator.rs`
+
+This file executes `git config --global` inside the container.
+
+```rust
+//! Container-side Git identity configuration.
+//!
+//! Executes `git config --global user.name` and
+//! `git config --global user.email` within a running container using
+//! the injected [`ContainerExecClient`].
+
+use crate::engine::{
+    ContainerExecClient, EngineConnector, ExecMode, ExecRequest,
+};
+use crate::error::PodbotError;
+
+use super::host_reader::HostGitIdentity;
+
+/// Outcome of configuring Git identity in a container.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum GitIdentityResult {
+    /// Both name and email were configured successfully.
+    Configured {
+        /// The configured `user.name`.
+        name: String,
+        /// The configured `user.email`.
+        email: String,
+    },
+    /// Only some identity fields were configured.
+    Partial {
+        /// The configured `user.name`, if set.
+        name: Option<String>,
+        /// The configured `user.email`, if set.
+        email: Option<String>,
+        /// Warning messages for missing fields.
+        warnings: Vec<String>,
+    },
+    /// No identity fields were available on the host.
+    NoneConfigured {
+        /// Warning messages explaining the absence.
+        warnings: Vec<String>,
+    },
+}
+
+/// Configure Git identity in a container using host-read values.
+///
+/// Executes `git config --global user.name` and/or
+/// `git config --global user.email` for each value present in
+/// `identity`. Missing values produce warnings rather than errors.
+///
+/// # Errors
+///
+/// Returns `ContainerError::ExecFailed` if a `git config` command
+/// fails inside the container.
+pub fn configure_git_identity<C: ContainerExecClient>(
+    runtime: &tokio::runtime::Handle,
+    client: &C,
+    container_id: &str,
+    identity: &HostGitIdentity,
+) -> Result<GitIdentityResult, PodbotError> {
+    match (&identity.name, &identity.email) {
+        (None, None) => Ok(GitIdentityResult::NoneConfigured {
+            warnings: vec![
+                String::from(
+                    "git user.name is not configured on the host",
+                ),
+                String::from(
+                    "git user.email is not configured on the host",
+                ),
+            ],
+        }),
+        (Some(name), Some(email)) => {
+            set_git_config(runtime, client, container_id, "user.name", name)?;
+            set_git_config(runtime, client, container_id, "user.email", email)?;
+            Ok(GitIdentityResult::Configured {
+                name: name.clone(),
+                email: email.clone(),
+            })
+        }
+        _ => configure_partial_identity(
+            runtime,
+            client,
+            container_id,
+            identity,
+        ),
+    }
+}
+
+fn configure_partial_identity<C: ContainerExecClient>(
+    runtime: &tokio::runtime::Handle,
+    client: &C,
+    container_id: &str,
+    identity: &HostGitIdentity,
+) -> Result<GitIdentityResult, PodbotError> {
+    let mut warnings = Vec::new();
+
+    if let Some(name) = &identity.name {
+        set_git_config(
+            runtime, client, container_id, "user.name", name,
+        )?;
+    } else {
+        warnings.push(String::from(
+            "git user.name is not configured on the host",
+        ));
+    }
+
+    if let Some(email) = &identity.email {
+        set_git_config(
+            runtime, client, container_id, "user.email", email,
+        )?;
+    } else {
+        warnings.push(String::from(
+            "git user.email is not configured on the host",
+        ));
+    }
+
+    Ok(GitIdentityResult::Partial {
+        name: identity.name.clone(),
+        email: identity.email.clone(),
+        warnings,
+    })
+}
+
+fn set_git_config<C: ContainerExecClient>(
+    runtime: &tokio::runtime::Handle,
+    client: &C,
+    container_id: &str,
+    key: &str,
+    value: &str,
+) -> Result<(), PodbotError> {
+    let command = vec![
+        String::from("git"),
+        String::from("config"),
+        String::from("--global"),
+        String::from(key),
+        String::from(value),
+    ];
+    let request = ExecRequest::new(
+        container_id,
+        command,
+        ExecMode::Detached,
+    )?;
+    let result = EngineConnector::exec(runtime, client, &request)?;
+
+    if result.exit_code() != 0 {
+        return Err(super::git_identity_exec_failed(
+            container_id,
+            format!(
+                "git config --global {key} failed with exit code {}",
+                result.exit_code()
+            ),
+        ));
+    }
+
+    Ok(())
+}
+```
+
+#### A.3: Create `src/engine/connection/git_identity/mod.rs`
+
+Module hub with re-exports.
+
+```rust
+//! Git identity configuration for containers.
+//!
+//! This module reads Git `user.name` and `user.email` from the host
+//! configuration and propagates them into a running container via
+//! `git config --global` exec commands.
+
+mod container_configurator;
+mod host_reader;
+
+pub use container_configurator::{
+    GitIdentityResult, configure_git_identity,
+};
+pub use host_reader::{
+    HostCommandRunner, HostGitIdentity, SystemCommandRunner,
+    read_host_git_identity,
+};
+
+use crate::error::{ContainerError, PodbotError};
+
+fn git_identity_exec_failed(
+    container_id: &str,
+    message: impl Into<String>,
+) -> PodbotError {
+    PodbotError::from(ContainerError::ExecFailed {
+        container_id: String::from(container_id),
+        message: message.into(),
+    })
+}
+
+#[cfg(test)]
+mod tests;
+```
+
+#### A.4: Create `src/engine/connection/git_identity/tests.rs`
+
+Unit tests using `rstest` and `mockall`.
+
+```rust
+//! Unit tests for Git identity configuration.
+
+use std::io;
+use std::os::unix::process::ExitStatusExt;
+use std::process::{ExitStatus, Output};
+
+use mockall::mock;
+use rstest::{fixture, rstest};
+
+use super::container_configurator::GitIdentityResult;
+use super::host_reader::{
+    HostCommandRunner, HostGitIdentity, read_host_git_identity,
+};
+use super::{configure_git_identity};
+
+// -- Host reader tests --
+
+mock! {
+    CommandRunner {}
+    impl HostCommandRunner for CommandRunner {
+        fn run_command(
+            &self,
+            program: &str,
+            args: &[&str],
+        ) -> io::Result<Output>;
+    }
+}
+
+fn success_output(stdout: &str) -> Output {
+    Output {
+        status: ExitStatus::from_raw(0),
+        stdout: stdout.as_bytes().to_vec(),
+        stderr: Vec::new(),
+    }
+}
+
+fn failure_output() -> Output {
+    Output {
+        status: ExitStatus::from_raw(256), // exit code 1
+        stdout: Vec::new(),
+        stderr: b"error".to_vec(),
+    }
+}
+
+#[rstest]
+fn read_identity_returns_both_when_configured() {
+    let mut runner = MockCommandRunner::new();
+    runner.expect_run_command()
+        .withf(|prog, args| {
+            prog == "git" && args == ["config", "--get", "user.name"]
+        })
+        .returning(|_, _| Ok(success_output("Alice\n")));
+    runner.expect_run_command()
+        .withf(|prog, args| {
+            prog == "git" && args == ["config", "--get", "user.email"]
+        })
+        .returning(|_, _| Ok(success_output("alice@example.com\n")));
+
+    let identity = read_host_git_identity(&runner);
+
+    assert_eq!(identity.name.as_deref(), Some("Alice"));
+    assert_eq!(identity.email.as_deref(), Some("alice@example.com"));
+}
+
+#[rstest]
+fn read_identity_returns_none_when_git_not_installed() {
+    let mut runner = MockCommandRunner::new();
+    runner.expect_run_command()
+        .returning(|_, _| {
+            Err(io::Error::new(io::ErrorKind::NotFound, "not found"))
+        });
+
+    let identity = read_host_git_identity(&runner);
+
+    assert!(identity.name.is_none());
+    assert!(identity.email.is_none());
+}
+
+#[rstest]
+fn read_identity_returns_none_for_unconfigured_fields() {
+    let mut runner = MockCommandRunner::new();
+    runner.expect_run_command()
+        .withf(|_, args| args.contains(&"user.name"))
+        .returning(|_, _| Ok(failure_output()));
+    runner.expect_run_command()
+        .withf(|_, args| args.contains(&"user.email"))
+        .returning(|_, _| Ok(success_output("bob@example.com\n")));
+
+    let identity = read_host_git_identity(&runner);
+
+    assert!(identity.name.is_none());
+    assert_eq!(identity.email.as_deref(), Some("bob@example.com"));
+}
+
+#[rstest]
+fn read_identity_trims_whitespace() {
+    let mut runner = MockCommandRunner::new();
+    runner.expect_run_command()
+        .withf(|_, args| args.contains(&"user.name"))
+        .returning(|_, _| Ok(success_output("  Alice  \n")));
+    runner.expect_run_command()
+        .withf(|_, args| args.contains(&"user.email"))
+        .returning(|_, _| Ok(success_output("  alice@example.com  \n")));
+
+    let identity = read_host_git_identity(&runner);
+
+    assert_eq!(identity.name.as_deref(), Some("Alice"));
+    assert_eq!(identity.email.as_deref(), Some("alice@example.com"));
+}
+
+#[rstest]
+fn read_identity_returns_none_for_empty_output() {
+    let mut runner = MockCommandRunner::new();
+    runner.expect_run_command()
+        .returning(|_, _| Ok(success_output("  \n")));
+
+    let identity = read_host_git_identity(&runner);
+
+    assert!(identity.name.is_none());
+    assert!(identity.email.is_none());
+}
+
+// Note: Container configurator tests use mock ContainerExecClient
+// and are in the BDD test suite (Stage C) for full integration
+// coverage. Additional unit tests for set_git_config error paths
+// are here.
+```
+
+#### A.5: Update `src/engine/connection/mod.rs`
+
+Add `mod git_identity;` and re-export public types:
+
+```rust
+mod git_identity;
+
+pub use git_identity::{
+    GitIdentityResult, HostCommandRunner, HostGitIdentity,
+    SystemCommandRunner, configure_git_identity,
+    read_host_git_identity,
+};
+```
+
+#### A.6: Update `src/engine/mod.rs`
+
+Add re-exports to the engine module's `pub use` block:
+
+```rust
+pub use connection::{
+    // ... existing re-exports ...
+    GitIdentityResult, HostCommandRunner, HostGitIdentity,
+    SystemCommandRunner, configure_git_identity,
+    read_host_git_identity,
+};
+```
+
+**Stage A gate**: run `make check-fmt && make lint && make test`.
+
+### Stage B: API orchestration function
+
+#### B.1: Create `src/api/configure_git_identity.rs`
+
+API-level orchestration function that composes host reading and
+container configuration.
+
+```rust
+//! Git identity configuration orchestration.
+//!
+//! Reads Git identity from the host and configures it within the
+//! container. Missing identity fields produce warnings rather than
+//! errors, following the principle that Git identity is helpful but
+//! not required for all container operations.
+
+use crate::engine::{
+    ContainerExecClient, GitIdentityResult, HostCommandRunner,
+    configure_git_identity as engine_configure,
+    read_host_git_identity,
+};
+use crate::error::Result as PodbotResult;
+
+/// Parameters for Git identity configuration.
+pub struct GitIdentityParams<'a, C: ContainerExecClient, R: HostCommandRunner> {
+    /// Pre-connected container engine client.
+    pub client: &'a C,
+    /// Host command runner for reading Git config.
+    pub host_runner: &'a R,
+    /// Target container identifier.
+    pub container_id: &'a str,
+    /// Tokio runtime handle for blocking execution.
+    pub runtime_handle: &'a tokio::runtime::Handle,
+}
+
+/// Read host Git identity and configure it in the container.
+///
+/// This is the top-level orchestration entry point for Step 4.1.
+/// Missing host identity fields result in a partial or none-configured
+/// result rather than an error.
+///
+/// # Errors
+///
+/// Returns `ContainerError::ExecFailed` if a `git config` command
+/// fails to execute within the container.
+pub fn configure_container_git_identity<
+    C: ContainerExecClient,
+    R: HostCommandRunner,
+>(
+    params: GitIdentityParams<'_, C, R>,
+) -> PodbotResult<GitIdentityResult> {
+    let identity = read_host_git_identity(params.host_runner);
+    engine_configure(
+        params.runtime_handle,
+        params.client,
+        params.container_id,
+        &identity,
+    )
+}
+```
+
+#### B.2: Update `src/api/mod.rs`
+
+Add the new module and re-export:
+
+```rust
+mod configure_git_identity;
+
+pub use configure_git_identity::{
+    GitIdentityParams, configure_container_git_identity,
+};
+```
+
+**Stage B gate**: run `make check-fmt && make lint && make test`.
+
+### Stage C: BDD behavioural tests
+
+#### C.1: Create `tests/features/git_identity.feature`
+
+```gherkin
+Feature: Git identity configuration
+
+  Configure Git identity within the container by reading
+  user.name and user.email from the host Git configuration.
+
+  Scenario: Both name and email are configured
+    Given host git user.name is Alice
+    And host git user.email is alice@example.com
+    And the container engine is available
+    When git identity configuration is requested for container sandbox-1
+    Then git identity result is configured
+    And configured name is Alice
+    And configured email is alice@example.com
+
+  Scenario: Only name is configured on the host
+    Given host git user.name is Bob
+    And host git user.email is missing
+    And the container engine is available
+    When git identity configuration is requested for container sandbox-2
+    Then git identity result is partial
+    And configured name is Bob
+    And configured email is absent
+    And warnings include git user.email is not configured on the host
+
+  Scenario: Only email is configured on the host
+    Given host git user.name is missing
+    And host git user.email is carol@example.com
+    And the container engine is available
+    When git identity configuration is requested for container sandbox-3
+    Then git identity result is partial
+    And configured name is absent
+    And configured email is carol@example.com
+    And warnings include git user.name is not configured on the host
+
+  Scenario: Neither name nor email is configured
+    Given host git user.name is missing
+    And host git user.email is missing
+    And the container engine is available
+    When git identity configuration is requested for container sandbox-4
+    Then git identity result is none configured
+    And warnings include git user.name is not configured on the host
+    And warnings include git user.email is not configured on the host
+
+  Scenario: Container exec failure propagates as error
+    Given host git user.name is Alice
+    And host git user.email is alice@example.com
+    And the container engine exec will fail
+    When git identity configuration is requested for container sandbox-5
+    Then git identity configuration fails with an exec error
+```
+
+#### C.2: Create `tests/bdd_git_identity_helpers/state.rs`
+
+State struct with `Slot<T>` fields for host identity, container ID,
+engine availability, and result.
+
+#### C.3: Create `tests/bdd_git_identity_helpers/steps.rs`
+
+Given/when step definitions using `mock!` for both `HostCommandRunner`
+and `ContainerExecClient`. The `when` step creates a tokio runtime,
+builds `GitIdentityParams`, and invokes
+`configure_container_git_identity()`.
+
+#### C.4: Create `tests/bdd_git_identity_helpers/assertions.rs`
+
+Then step definitions for verifying `GitIdentityResult` variants,
+configured values, warnings, and error outcomes.
+
+#### C.5: Create `tests/bdd_git_identity_helpers/mod.rs`
+
+Re-export hub with `StepResult<T>` type alias and
+`#[expect(unused_imports)]` on step/assertion imports.
+
+#### C.6: Create `tests/bdd_git_identity.rs`
+
+Scenario bindings using `#[scenario]` macros, one function per scenario.
+
+**Stage C gate**: run `make check-fmt && make lint && make test`.
+
+### Stage D: Documentation updates
+
+#### D.1: Update `docs/podbot-design.md`
+
+No structural changes needed; the design doc already describes step 3
+(Git identity configuration). If the module structure section exists,
+add the `git_identity/` entry under `engine/connection/`.
+
+#### D.2: Update `docs/users-guide.md`
+
+Add a "Git identity configuration" section under "Container creation
+behaviour" (or similar):
+
+```markdown
+### Git identity configuration
+
+At sandbox startup, podbot reads Git identity (`user.name` and
+`user.email`) from the host Git configuration and executes
+`git config --global` within the container to propagate these values.
+
+- If both values are present, they are configured in the container.
+- If only one value is present, the available value is configured and
+  a warning is produced for the missing field.
+- If neither value is present, podbot warns but does not fail.
+- If the host `git` binary is not installed, both values are treated
+  as absent.
+
+This ensures that Git commits made within the container use the
+operator's identity without requiring manual configuration inside the
+sandbox.
+```
+
+#### D.3: Update `docs/podbot-roadmap.md`
+
+Mark Step 4.1 tasks as done:
+
+```markdown
+- [x] Read user.name from host Git configuration.
+- [x] Read user.email from host Git configuration.
+- [x] Execute git config --global user.name within the container.
+- [x] Execute git config --global user.email within the container.
+- [x] Handle missing Git identity with a warning rather than failure.
+```
+
+#### D.4: Save execution plan
+
+Update this file with completion status and retrospective.
+
+**Stage D gate**: run full gate stack.
+
+### Stage E: Final verification
+
+Run the full quality gate:
+
+```bash
+set -o pipefail
+make check-fmt 2>&1 | tee /tmp/check-fmt-4-1-1.log
+make lint 2>&1 | tee /tmp/lint-4-1-1.log
+make test 2>&1 | tee /tmp/test-4-1-1.log
+```
+
+Verify all pre-existing tests pass unchanged. Verify new tests pass.
+
+## Interfaces and dependencies
+
+### New public types
+
+In `src/engine/connection/git_identity/host_reader.rs`:
+
+```rust
+pub trait HostCommandRunner {
+    fn run_command(&self, program: &str, args: &[&str])
+        -> io::Result<Output>;
+}
+
+pub struct SystemCommandRunner;
+
+pub struct HostGitIdentity {
+    pub name: Option<String>,
+    pub email: Option<String>,
+}
+```
+
+In `src/engine/connection/git_identity/container_configurator.rs`:
+
+```rust
+pub enum GitIdentityResult {
+    Configured { name: String, email: String },
+    Partial {
+        name: Option<String>,
+        email: Option<String>,
+        warnings: Vec<String>,
+    },
+    NoneConfigured { warnings: Vec<String> },
+}
+```
+
+In `src/api/configure_git_identity.rs`:
+
+```rust
+pub struct GitIdentityParams<'a, C, R> { ... }
+
+pub fn configure_container_git_identity<C, R>(
+    params: GitIdentityParams<'_, C, R>,
+) -> PodbotResult<GitIdentityResult>;
+```
+
+### Consumed (not modified) dependencies
+
+- `podbot::engine::ContainerExecClient` -- trait for container exec
+- `podbot::engine::EngineConnector::exec()` -- blocking exec helper
+- `podbot::engine::ExecRequest`, `ExecMode::Detached` -- request types
+- `podbot::error::ContainerError::ExecFailed` -- error variant
+- `std::process::Command` -- host-side command execution (in production)
+
+No new external crate dependencies are required.
+
+## Files to create
+
+| File | Purpose |
+| --- | --- |
+| `src/engine/connection/git_identity/mod.rs` | Module hub and re-exports |
+| `src/engine/connection/git_identity/host_reader.rs` | Host Git config reader trait and impl |
+| `src/engine/connection/git_identity/container_configurator.rs` | Container `git config` executor |
+| `src/engine/connection/git_identity/tests.rs` | Unit tests for host reader |
+| `src/api/configure_git_identity.rs` | API orchestration function |
+| `tests/features/git_identity.feature` | BDD scenarios |
+| `tests/bdd_git_identity.rs` | Scenario bindings |
+| `tests/bdd_git_identity_helpers/mod.rs` | Re-exports |
+| `tests/bdd_git_identity_helpers/state.rs` | State + fixture |
+| `tests/bdd_git_identity_helpers/steps.rs` | Given/when steps |
+| `tests/bdd_git_identity_helpers/assertions.rs` | Then assertions |
+
+## Files to modify
+
+| File | Change |
+| --- | --- |
+| `src/engine/connection/mod.rs` | Add `mod git_identity;` and re-exports |
+| `src/engine/mod.rs` | Add Git identity types to `pub use` block |
+| `src/api/mod.rs` | Add `mod configure_git_identity;` and re-export |
+| `docs/podbot-design.md` | Add `git_identity/` module entry if needed |
+| `docs/users-guide.md` | Add Git identity configuration section |
+| `docs/podbot-roadmap.md` | Mark Step 4.1 tasks as done |
+
+## Validation and acceptance
+
+Quality criteria:
+
+- `make check-fmt` passes (cargo fmt workspace check).
+- `make lint` passes (clippy with all warnings denied, cargo doc).
+- `make test` passes (all existing and new tests).
+- Unit test: host reader returns both fields when configured.
+- Unit test: host reader returns `None` when `git` is not installed.
+- Unit test: host reader returns `None` for unconfigured fields.
+- Unit test: host reader trims whitespace from output.
+- BDD scenario: both name and email configured in container.
+- BDD scenario: partial identity produces warnings.
+- BDD scenario: no identity produces warnings, no failure.
+- BDD scenario: container exec failure propagates as error.
+- All pre-existing tests pass unchanged.
+
+Quality method:
+
+```bash
+set -o pipefail
+make check-fmt 2>&1 | tee /tmp/check-fmt-4-1-1.log
+make lint 2>&1 | tee /tmp/lint-4-1-1.log
+make test 2>&1 | tee /tmp/test-4-1-1.log
+```
+
+## Idempotence and recovery
+
+All stages are additive and can be rerun safely. If partial edits leave
+the tree failing, revert only incomplete hunks and replay the current
+stage. `cargo clean -p podbot` may be needed after modifying feature
+files (rstest-bdd reads them at compile time). Gate logs stored under
+`/tmp` with unique names per run.
+
+## Implementation order
+
+1. `src/engine/connection/git_identity/host_reader.rs` -- host reader
+   trait and function
+2. `src/engine/connection/git_identity/container_configurator.rs` --
+   container exec logic
+3. `src/engine/connection/git_identity/mod.rs` -- module hub
+4. `src/engine/connection/git_identity/tests.rs` -- unit tests
+5. `src/engine/connection/mod.rs` -- add module and re-exports
+6. `src/engine/mod.rs` -- add re-exports
+7. Gate check (Stage A)
+8. `src/api/configure_git_identity.rs` -- API function
+9. `src/api/mod.rs` -- add module and re-export
+10. Gate check (Stage B)
+11. `tests/features/git_identity.feature` -- BDD scenarios
+12. `tests/bdd_git_identity_helpers/state.rs` -- state struct
+13. `tests/bdd_git_identity_helpers/steps.rs` -- step definitions
+14. `tests/bdd_git_identity_helpers/assertions.rs` -- assertions
+15. `tests/bdd_git_identity_helpers/mod.rs` -- re-exports
+16. `tests/bdd_git_identity.rs` -- scenario bindings
+17. Gate check (Stage C)
+18. `docs/podbot-design.md` -- update if needed
+19. `docs/users-guide.md` -- add Git identity section
+20. `docs/podbot-roadmap.md` -- mark tasks done
+21. Gate check (Stage D)
+22. Final gate check (Stage E)

--- a/docs/execplans/4-1-1-git-identity-configuration.md
+++ b/docs/execplans/4-1-1-git-identity-configuration.md
@@ -56,7 +56,8 @@ escalation, not workarounds.
 - No new external crate dependencies may be added.
 - `rstest` for unit tests; `rstest-bdd` v0.5.0 for behavioural tests.
 - BDD step function parameter names must match fixture names exactly.
-- BDD feature files must use unquoted text for `{param}` captures.
+- BDD feature files must use quoted values with `{string}` captures
+  (e.g., `Given host git user.name is "Alice"`).
 - BDD tests must use `StepResult<T> = Result<T, String>` pattern (no
   `expect`/`panic`).
 - `make check-fmt`, `make lint`, `make test` must pass before any commit.

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -611,6 +611,7 @@ or calling `std::process::exit`.
 | `podbot::api::stop_container(container)`   | Stop a running container (stub)                 |
 | `podbot::api::list_containers()`           | List running podbot containers (stub)           |
 | `podbot::api::run_token_daemon(container)` | Run the token refresh daemon (stub)             |
+| `podbot::api::configure_container_git_identity(params)` | Configure Git identity inside a container from host Git config |
 
 ### Return type
 
@@ -649,6 +650,73 @@ fn run_command(
 }
 ```
 
+### Git identity configuration
+
+`configure_container_git_identity` reads `user.name` and `user.email` from
+the host Git configuration and applies them inside a running container via
+`git config --global`. Missing fields produce warnings rather than errors.
+
+#### Parameters: `GitIdentityParams`
+
+```rust,no_run
+pub struct GitIdentityParams<'a, C: ContainerExecClient, R: HostCommandRunner> {
+    pub client: &'a C,
+    pub host_runner: &'a R,
+    pub container_id: &'a str,
+    pub runtime_handle: &'a tokio::runtime::Handle,
+}
+```
+
+#### Return type: `GitIdentityResult`
+
+`configure_container_git_identity` returns `podbot::error::Result<GitIdentityResult>`:
+
+| Variant | Meaning |
+| ------- | ------- |
+| `GitIdentityResult::Configured { name, email }` | Both `user.name` and `user.email` were set in the container. |
+| `GitIdentityResult::Partial { name, email, warnings }` | One field was set; `warnings` explains the missing field. |
+| `GitIdentityResult::NoneConfigured { warnings }` | Neither field was present on the host; container Git config unchanged. |
+
+Container-side exec failures (e.g. `git` not present in the container image)
+propagate as `PodbotError::Container(ContainerError::ExecFailed { .. })`.
+
+#### Example usage
+
+```rust,no_run
+use podbot::api::{GitIdentityParams, configure_container_git_identity};
+use podbot::engine::{GitIdentityResult, SystemCommandRunner};
+
+fn configure_identity(
+    client: &impl podbot::engine::ContainerExecClient,
+    runtime_handle: &tokio::runtime::Handle,
+) {
+    let host_runner = SystemCommandRunner;
+    let params = GitIdentityParams {
+        client,
+        host_runner: &host_runner,
+        container_id: "my-container",
+        runtime_handle,
+    };
+
+    match configure_container_git_identity(&params) {
+        Ok(GitIdentityResult::Configured { name, email }) => {
+            println!("Git identity set: {name} <{email}>");
+        }
+        Ok(GitIdentityResult::Partial { warnings, .. }) => {
+            for w in &warnings {
+                eprintln!("warning: {w}");
+            }
+        }
+        Ok(GitIdentityResult::NoneConfigured { warnings }) => {
+            for w in &warnings {
+                eprintln!("warning: {w}");
+            }
+        }
+        Err(e) => eprintln!("Error configuring Git identity: {e}"),
+    }
+}
+```
+
 ### Library embedding
 
 Podbot can be used as a library dependency without the CLI adapter layer. The
@@ -674,7 +742,8 @@ feature flag controls module visibility, not the `clap` dependency itself.
 The following modules are part of the stable public API:
 
 - `podbot::api` — orchestration functions (`exec`, `run_agent`,
-  `list_containers`, `stop_container`, `run_token_daemon`)
+  `list_containers`, `stop_container`, `run_token_daemon`,
+  `configure_container_git_identity`)
 - `podbot::config` — configuration types and loaders (`AppConfig`,
   `ConfigLoadOptions`, `load_config`)
 - `podbot::engine` — container engine types and traits

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -604,22 +604,27 @@ or calling `std::process::exit`.
 
 ### Available functions
 
-| Function                                   | Description                                     |
-| ------------------------------------------ | ----------------------------------------------- |
-| `podbot::api::exec(params)`                | Execute a command in a running container        |
-| `podbot::api::run_agent(config)`           | Run an AI agent in a sandboxed container (stub) |
-| `podbot::api::stop_container(container)`   | Stop a running container (stub)                 |
-| `podbot::api::list_containers()`           | List running podbot containers (stub)           |
-| `podbot::api::run_token_daemon(container)` | Run the token refresh daemon (stub)             |
-| `podbot::api::configure_container_git_identity(params)` | Configure Git identity inside a container from host Git config |
+| Function                                                | Description                                                     |
+| ------------------------------------------------------- | --------------------------------------------------------------- |
+| `podbot::api::exec(params)`                             | Execute a command in a running container                        |
+| `podbot::api::run_agent(config)`                        | Run an AI agent in a sandboxed container (stub)                 |
+| `podbot::api::stop_container(container)`                | Stop a running container (stub)                                 |
+| `podbot::api::list_containers()`                        | List running podbot containers (stub)                           |
+| `podbot::api::run_token_daemon(container)`              | Run the token refresh daemon (stub)                             |
+| `podbot::api::configure_container_git_identity(params)` | Configure Git identity inside a container from host Git config  |
 
-### Return type
+### Return types
 
-All orchestration functions return `podbot::error::Result<CommandOutcome>`:
+Most orchestration functions return `podbot::error::Result<CommandOutcome>`:
 
 - `CommandOutcome::Success` indicates a zero exit code.
 - `CommandOutcome::CommandExit { code }` carries the non-zero exit code
   reported by the container engine.
+
+The `configure_container_git_identity` function returns
+`podbot::error::Result<GitIdentityResult>` instead, which provides structured
+information about the Git identity configuration outcome. See the "Git identity
+configuration" section below for details.
 
 ### Example usage
 
@@ -680,7 +685,7 @@ pub struct GitIdentityParams<'a, C: ContainerExecClient, R: HostCommandRunner> {
 Container-side exec failures (e.g. `git` not present in the container image)
 propagate as `PodbotError::Container(ContainerError::ExecFailed { .. })`.
 
-#### Example usage
+#### Example: configuring Git identity
 
 ```rust,no_run
 use podbot::api::{GitIdentityParams, configure_container_git_identity};

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -611,7 +611,7 @@ or calling `std::process::exit`.
 | `podbot::api::stop_container(container)`                | Stop a running container (stub)                                 |
 | `podbot::api::list_containers()`                        | List running podbot containers (stub)                           |
 | `podbot::api::run_token_daemon(container)`              | Run the token refresh daemon (stub)                             |
-| `podbot::api::configure_container_git_identity(params)` | Configure Git identity inside a container from host Git config  |
+| `podbot::api::configure_container_git_identity(params)` | Configure Git identity from host Git config                     |
 
 ### Return types
 

--- a/src/api/configure_git_identity.rs
+++ b/src/api/configure_git_identity.rs
@@ -48,12 +48,13 @@ pub fn configure_container_git_identity<C: ContainerExecClient, R: HostCommandRu
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::engine::test_helpers::{failure_output, success_output};
     use crate::engine::{CreateExecFuture, InspectExecFuture, ResizeExecFuture, StartExecFuture};
 
     use bollard::exec::{CreateExecOptions, ResizeExecOptions, StartExecOptions};
     use mockall::mock;
     use std::io;
-    use std::process::{ExitStatus, Output};
+    use std::process::Output;
 
     mock! {
         HostRunner {}
@@ -85,35 +86,6 @@ mod tests {
                 exec_id: &str,
                 options: ResizeExecOptions,
             ) -> ResizeExecFuture<'_>;
-        }
-    }
-
-    /// Platform-independent exit status construction.
-    #[cfg(unix)]
-    fn exit_status(code: i32) -> ExitStatus {
-        use std::os::unix::process::ExitStatusExt;
-        ExitStatus::from_raw(code << 8)
-    }
-
-    #[cfg(windows)]
-    fn exit_status(code: i32) -> ExitStatus {
-        use std::os::windows::process::ExitStatusExt;
-        ExitStatus::from_raw(code as u32)
-    }
-
-    fn success_output(stdout: &str) -> Output {
-        Output {
-            status: exit_status(0),
-            stdout: stdout.as_bytes().to_vec(),
-            stderr: Vec::new(),
-        }
-    }
-
-    fn failure_output() -> Output {
-        Output {
-            status: exit_status(1),
-            stdout: Vec::new(),
-            stderr: b"error".to_vec(),
         }
     }
 
@@ -165,25 +137,33 @@ mod tests {
         client
     }
 
+    /// Shared test plumbing: creates a Tokio runtime, builds
+    /// `GitIdentityParams`, and calls `configure_container_git_identity`.
+    fn invoke(
+        host_runner: &MockHostRunner,
+        exec_client: &MockExecClient,
+        container_id: &str,
+    ) -> PodbotResult<GitIdentityResult> {
+        let runtime = tokio::runtime::Runtime::new().expect("test requires a Tokio runtime");
+        let handle = runtime.handle().clone();
+        let params = GitIdentityParams {
+            client: exec_client,
+            host_runner,
+            container_id,
+            runtime_handle: &handle,
+        };
+        configure_container_git_identity(&params)
+    }
+
     #[test]
     fn returns_configured_when_both_fields_present() {
         let mut host_runner = MockHostRunner::new();
         register_host_config(&mut host_runner, "user.name", Some("Alice"));
         register_host_config(&mut host_runner, "user.email", Some("alice@example.com"));
-
         let exec_client = make_exec_client(0);
-        let runtime = tokio::runtime::Runtime::new().expect("test requires a Tokio runtime");
-        let handle = runtime.handle().clone();
 
-        let params = GitIdentityParams {
-            client: &exec_client,
-            host_runner: &host_runner,
-            container_id: "sandbox-unit",
-            runtime_handle: &handle,
-        };
-
-        let result =
-            configure_container_git_identity(&params).expect("should succeed with Configured");
+        let result = invoke(&host_runner, &exec_client, "sandbox-unit")
+            .expect("should succeed with Configured");
 
         assert!(
             matches!(result, GitIdentityResult::Configured { .. }),
@@ -196,21 +176,10 @@ mod tests {
         let mut host_runner = MockHostRunner::new();
         register_host_config(&mut host_runner, "user.name", None);
         register_host_config(&mut host_runner, "user.email", None);
+        let exec_client = MockExecClient::new(); // no exec calls expected
 
-        // No exec calls expected when both fields are absent.
-        let exec_client = MockExecClient::new();
-        let runtime = tokio::runtime::Runtime::new().expect("test requires a Tokio runtime");
-        let handle = runtime.handle().clone();
-
-        let params = GitIdentityParams {
-            client: &exec_client,
-            host_runner: &host_runner,
-            container_id: "sandbox-unit-2",
-            runtime_handle: &handle,
-        };
-
-        let result =
-            configure_container_git_identity(&params).expect("should succeed with NoneConfigured");
+        let result = invoke(&host_runner, &exec_client, "sandbox-unit-2")
+            .expect("should succeed with NoneConfigured");
 
         assert!(
             matches!(result, GitIdentityResult::NoneConfigured { .. }),

--- a/src/api/configure_git_identity.rs
+++ b/src/api/configure_git_identity.rs
@@ -1,0 +1,46 @@
+//! Git identity configuration orchestration.
+//!
+//! Reads Git identity from the host and configures it within the
+//! container. Missing identity fields produce warnings rather than
+//! errors, following the principle that Git identity is helpful but
+//! not required for all container operations.
+
+use crate::engine::{
+    ContainerExecClient, GitIdentityResult, HostCommandRunner,
+    configure_git_identity as engine_configure, read_host_git_identity,
+};
+use crate::error::Result as PodbotResult;
+
+/// Parameters for Git identity configuration.
+pub struct GitIdentityParams<'a, C: ContainerExecClient, R: HostCommandRunner> {
+    /// Pre-connected container engine client.
+    pub client: &'a C,
+    /// Host command runner for reading Git config.
+    pub host_runner: &'a R,
+    /// Target container identifier.
+    pub container_id: &'a str,
+    /// Tokio runtime handle for blocking execution.
+    pub runtime_handle: &'a tokio::runtime::Handle,
+}
+
+/// Read host Git identity and configure it in the container.
+///
+/// This is the top-level orchestration entry point for Step 4.1.
+/// Missing host identity fields result in a partial or none-configured
+/// result rather than an error.
+///
+/// # Errors
+///
+/// Returns `ContainerError::ExecFailed` if a `git config` command
+/// fails to execute within the container.
+pub fn configure_container_git_identity<C: ContainerExecClient, R: HostCommandRunner>(
+    params: &GitIdentityParams<'_, C, R>,
+) -> PodbotResult<GitIdentityResult> {
+    let identity = read_host_git_identity(params.host_runner);
+    engine_configure(
+        params.runtime_handle,
+        params.client,
+        params.container_id,
+        &identity,
+    )
+}

--- a/src/api/configure_git_identity.rs
+++ b/src/api/configure_git_identity.rs
@@ -44,3 +44,177 @@ pub fn configure_container_git_identity<C: ContainerExecClient, R: HostCommandRu
         &identity,
     )
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::engine::{CreateExecFuture, InspectExecFuture, ResizeExecFuture, StartExecFuture};
+
+    use bollard::exec::{CreateExecOptions, ResizeExecOptions, StartExecOptions};
+    use mockall::mock;
+    use std::io;
+    use std::process::{ExitStatus, Output};
+
+    mock! {
+        HostRunner {}
+        impl HostCommandRunner for HostRunner {
+            fn run_command<'a>(
+                &self,
+                program: &'a str,
+                args: &'a [&'a str],
+            ) -> io::Result<Output>;
+        }
+    }
+
+    mock! {
+        ExecClient {}
+        impl ContainerExecClient for ExecClient {
+            fn create_exec(
+                &self,
+                container_id: &str,
+                options: CreateExecOptions<String>,
+            ) -> CreateExecFuture<'_>;
+            fn start_exec(
+                &self,
+                exec_id: &str,
+                options: Option<StartExecOptions>,
+            ) -> StartExecFuture<'_>;
+            fn inspect_exec(&self, exec_id: &str) -> InspectExecFuture<'_>;
+            fn resize_exec(
+                &self,
+                exec_id: &str,
+                options: ResizeExecOptions,
+            ) -> ResizeExecFuture<'_>;
+        }
+    }
+
+    /// Platform-independent exit status construction.
+    #[cfg(unix)]
+    fn exit_status(code: i32) -> ExitStatus {
+        use std::os::unix::process::ExitStatusExt;
+        ExitStatus::from_raw(code << 8)
+    }
+
+    #[cfg(windows)]
+    fn exit_status(code: i32) -> ExitStatus {
+        use std::os::windows::process::ExitStatusExt;
+        ExitStatus::from_raw(code as u32)
+    }
+
+    fn success_output(stdout: &str) -> Output {
+        Output {
+            status: exit_status(0),
+            stdout: stdout.as_bytes().to_vec(),
+            stderr: Vec::new(),
+        }
+    }
+
+    fn failure_output() -> Output {
+        Output {
+            status: exit_status(1),
+            stdout: Vec::new(),
+            stderr: b"error".to_vec(),
+        }
+    }
+
+    /// Register a host runner expectation matching `config_key`, returning
+    /// `success_output` for `Some` values or `failure_output` for `None`.
+    fn register_host_config(
+        runner: &mut MockHostRunner,
+        config_key: &'static str,
+        value: Option<&str>,
+    ) {
+        match value {
+            Some(v) => {
+                let owned = String::from(v);
+                runner
+                    .expect_run_command()
+                    .withf(move |_, args| args.contains(&config_key))
+                    .returning(move |_, _| Ok(success_output(&format!("{owned}\n"))));
+            }
+            None => {
+                runner
+                    .expect_run_command()
+                    .withf(move |_, args| args.contains(&config_key))
+                    .returning(|_, _| Ok(failure_output()));
+            }
+        }
+    }
+
+    fn make_exec_client(exit_code: i64) -> MockExecClient {
+        let mut client = MockExecClient::new();
+        client.expect_create_exec().returning(|_, _| {
+            Box::pin(async {
+                Ok(bollard::exec::CreateExecResults {
+                    id: String::from("exec-1"),
+                })
+            })
+        });
+        client
+            .expect_start_exec()
+            .returning(|_, _| Box::pin(async { Ok(bollard::exec::StartExecResults::Detached) }));
+        client.expect_inspect_exec().returning(move |_| {
+            Box::pin(async move {
+                Ok(bollard::models::ExecInspectResponse {
+                    exit_code: Some(exit_code),
+                    running: Some(false),
+                    ..Default::default()
+                })
+            })
+        });
+        client
+    }
+
+    #[test]
+    fn returns_configured_when_both_fields_present() {
+        let mut host_runner = MockHostRunner::new();
+        register_host_config(&mut host_runner, "user.name", Some("Alice"));
+        register_host_config(&mut host_runner, "user.email", Some("alice@example.com"));
+
+        let exec_client = make_exec_client(0);
+        let runtime = tokio::runtime::Runtime::new().expect("test requires a Tokio runtime");
+        let handle = runtime.handle().clone();
+
+        let params = GitIdentityParams {
+            client: &exec_client,
+            host_runner: &host_runner,
+            container_id: "sandbox-unit",
+            runtime_handle: &handle,
+        };
+
+        let result =
+            configure_container_git_identity(&params).expect("should succeed with Configured");
+
+        assert!(
+            matches!(result, GitIdentityResult::Configured { .. }),
+            "Expected Configured, got {result:?}"
+        );
+    }
+
+    #[test]
+    fn returns_none_configured_when_both_fields_absent() {
+        let mut host_runner = MockHostRunner::new();
+        register_host_config(&mut host_runner, "user.name", None);
+        register_host_config(&mut host_runner, "user.email", None);
+
+        // No exec calls expected when both fields are absent.
+        let exec_client = MockExecClient::new();
+        let runtime = tokio::runtime::Runtime::new().expect("test requires a Tokio runtime");
+        let handle = runtime.handle().clone();
+
+        let params = GitIdentityParams {
+            client: &exec_client,
+            host_runner: &host_runner,
+            container_id: "sandbox-unit-2",
+            runtime_handle: &handle,
+        };
+
+        let result =
+            configure_container_git_identity(&params).expect("should succeed with NoneConfigured");
+
+        assert!(
+            matches!(result, GitIdentityResult::NoneConfigured { .. }),
+            "Expected NoneConfigured, got {result:?}"
+        );
+    }
+}

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -2,9 +2,10 @@
 //!
 //! This module provides public orchestration functions for each podbot
 //! command: [`exec`], [`run_agent`], [`stop_container`], [`list_containers`],
-//! and [`run_token_daemon`]. These functions contain the business logic that
-//! was previously embedded in the CLI binary, making it available to both
-//! the CLI adapter and library embedders.
+//! [`run_token_daemon`], and [`configure_container_git_identity`]. These
+//! functions contain the business logic that was previously embedded in the
+//! CLI binary, making it available to both the CLI adapter and library
+//! embedders.
 //!
 //! All functions accept library-owned types (not clap types) and return
 //! [`crate::error::Result<CommandOutcome>`]. They do not print to

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -8,7 +8,9 @@
 //! embedders.
 //!
 //! All functions accept library-owned types (not clap types) and return
-//! [`crate::error::Result<CommandOutcome>`]. They do not print to
+//! [`crate::error::Result<T>`] — for example, [`run_token_daemon`] returns
+//! `PodbotResult<CommandOutcome>` while [`configure_container_git_identity`]
+//! returns `PodbotResult<GitIdentityResult>`. They do not print to
 //! stdout/stderr or call `std::process::exit`.
 
 mod configure_git_identity;

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -10,8 +10,10 @@
 //! [`crate::error::Result<CommandOutcome>`]. They do not print to
 //! stdout/stderr or call `std::process::exit`.
 
+mod configure_git_identity;
 mod exec;
 
+pub use configure_git_identity::{GitIdentityParams, configure_container_git_identity};
 pub use exec::{ExecParams, exec};
 
 use crate::config::AppConfig;

--- a/src/engine/connection/git_identity/container_configurator.rs
+++ b/src/engine/connection/git_identity/container_configurator.rs
@@ -194,6 +194,7 @@ mod tests {
 
     use bollard::exec::{CreateExecOptions, ResizeExecOptions, StartExecOptions};
     use mockall::mock;
+    use rstest::rstest;
 
     mock! {
         ExecClient {}
@@ -292,13 +293,19 @@ mod tests {
         }
     }
 
-    #[test]
-    fn returns_partial_when_only_name_present() {
+    #[rstest]
+    #[case(Some("Bob"), None, "user.email")]
+    #[case(None, Some("carol@example.com"), "user.name")]
+    fn returns_partial_when_one_field_present(
+        #[case] name: Option<&str>,
+        #[case] email: Option<&str>,
+        #[case] missing_warning: &str,
+    ) {
         let (_rt, handle) = make_runtime();
         let client = make_exec_client(0);
         let identity = HostGitIdentity {
-            name: Some(String::from("Bob")),
-            email: None,
+            name: name.map(String::from),
+            email: email.map(String::from),
         };
 
         let result = configure_git_identity(&handle, &client, "c3", &identity)
@@ -309,42 +316,17 @@ mod tests {
             "Expected Partial, got {result:?}"
         );
         if let GitIdentityResult::Partial {
-            name,
-            email,
+            name: actual_name,
+            email: actual_email,
             warnings,
         } = result
         {
-            assert_eq!(name.as_deref(), Some("Bob"));
-            assert!(email.is_none());
-            assert!(warnings.iter().any(|w| w.contains("user.email")));
-        }
-    }
-
-    #[test]
-    fn returns_partial_when_only_email_present() {
-        let (_rt, handle) = make_runtime();
-        let client = make_exec_client(0);
-        let identity = HostGitIdentity {
-            name: None,
-            email: Some(String::from("carol@example.com")),
-        };
-
-        let result = configure_git_identity(&handle, &client, "c4", &identity)
-            .expect("should succeed with Partial");
-
-        assert!(
-            matches!(result, GitIdentityResult::Partial { .. }),
-            "Expected Partial, got {result:?}"
-        );
-        if let GitIdentityResult::Partial {
-            name,
-            email,
-            warnings,
-        } = result
-        {
-            assert!(name.is_none());
-            assert_eq!(email.as_deref(), Some("carol@example.com"));
-            assert!(warnings.iter().any(|w| w.contains("user.name")));
+            assert_eq!(actual_name.as_deref(), name);
+            assert_eq!(actual_email.as_deref(), email);
+            assert!(
+                warnings.iter().any(|w| w.contains(missing_warning)),
+                "Expected warning containing '{missing_warning}', got {warnings:?}"
+            );
         }
     }
 

--- a/src/engine/connection/git_identity/container_configurator.rs
+++ b/src/engine/connection/git_identity/container_configurator.rs
@@ -185,3 +185,183 @@ fn set_git_config<C: ContainerExecClient>(
 
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::engine::connection::git_identity::host_reader::HostGitIdentity;
+    use crate::engine::{CreateExecFuture, InspectExecFuture, ResizeExecFuture, StartExecFuture};
+
+    use bollard::exec::{CreateExecOptions, ResizeExecOptions, StartExecOptions};
+    use mockall::mock;
+
+    mock! {
+        ExecClient {}
+        impl ContainerExecClient for ExecClient {
+            fn create_exec(
+                &self,
+                container_id: &str,
+                options: CreateExecOptions<String>,
+            ) -> CreateExecFuture<'_>;
+            fn start_exec(
+                &self,
+                exec_id: &str,
+                options: Option<StartExecOptions>,
+            ) -> StartExecFuture<'_>;
+            fn inspect_exec(&self, exec_id: &str) -> InspectExecFuture<'_>;
+            fn resize_exec(
+                &self,
+                exec_id: &str,
+                options: ResizeExecOptions,
+            ) -> ResizeExecFuture<'_>;
+        }
+    }
+
+    fn make_runtime() -> (tokio::runtime::Runtime, tokio::runtime::Handle) {
+        let rt = tokio::runtime::Runtime::new().expect("test requires a Tokio runtime");
+        let handle = rt.handle().clone();
+        (rt, handle)
+    }
+
+    fn make_exec_client(exit_code: i64) -> MockExecClient {
+        let mut client = MockExecClient::new();
+        client.expect_create_exec().returning(|_, _| {
+            Box::pin(async {
+                Ok(bollard::exec::CreateExecResults {
+                    id: String::from("exec-1"),
+                })
+            })
+        });
+        client
+            .expect_start_exec()
+            .returning(|_, _| Box::pin(async { Ok(bollard::exec::StartExecResults::Detached) }));
+        client.expect_inspect_exec().returning(move |_| {
+            Box::pin(async move {
+                Ok(bollard::models::ExecInspectResponse {
+                    exit_code: Some(exit_code),
+                    running: Some(false),
+                    ..Default::default()
+                })
+            })
+        });
+        client
+    }
+
+    #[test]
+    fn returns_none_configured_when_both_fields_absent() {
+        let (_rt, handle) = make_runtime();
+        // No exec expectations — no container commands should be issued.
+        let client = MockExecClient::new();
+        let identity = HostGitIdentity {
+            name: None,
+            email: None,
+        };
+
+        let result = configure_git_identity(&handle, &client, "c1", &identity)
+            .expect("should succeed with NoneConfigured");
+
+        assert!(
+            matches!(result, GitIdentityResult::NoneConfigured { .. }),
+            "Expected NoneConfigured, got {result:?}"
+        );
+        if let GitIdentityResult::NoneConfigured { warnings } = result {
+            assert!(warnings.iter().any(|w| w.contains("user.name")));
+            assert!(warnings.iter().any(|w| w.contains("user.email")));
+        }
+    }
+
+    #[test]
+    fn returns_configured_when_both_fields_present() {
+        let (_rt, handle) = make_runtime();
+        let client = make_exec_client(0);
+        let identity = HostGitIdentity {
+            name: Some(String::from("Alice")),
+            email: Some(String::from("alice@example.com")),
+        };
+
+        let result = configure_git_identity(&handle, &client, "c2", &identity)
+            .expect("should succeed with Configured");
+
+        assert!(
+            matches!(result, GitIdentityResult::Configured { .. }),
+            "Expected Configured, got {result:?}"
+        );
+        if let GitIdentityResult::Configured { name, email } = result {
+            assert_eq!(name, "Alice");
+            assert_eq!(email, "alice@example.com");
+        }
+    }
+
+    #[test]
+    fn returns_partial_when_only_name_present() {
+        let (_rt, handle) = make_runtime();
+        let client = make_exec_client(0);
+        let identity = HostGitIdentity {
+            name: Some(String::from("Bob")),
+            email: None,
+        };
+
+        let result = configure_git_identity(&handle, &client, "c3", &identity)
+            .expect("should succeed with Partial");
+
+        assert!(
+            matches!(result, GitIdentityResult::Partial { .. }),
+            "Expected Partial, got {result:?}"
+        );
+        if let GitIdentityResult::Partial {
+            name,
+            email,
+            warnings,
+        } = result
+        {
+            assert_eq!(name.as_deref(), Some("Bob"));
+            assert!(email.is_none());
+            assert!(warnings.iter().any(|w| w.contains("user.email")));
+        }
+    }
+
+    #[test]
+    fn returns_partial_when_only_email_present() {
+        let (_rt, handle) = make_runtime();
+        let client = make_exec_client(0);
+        let identity = HostGitIdentity {
+            name: None,
+            email: Some(String::from("carol@example.com")),
+        };
+
+        let result = configure_git_identity(&handle, &client, "c4", &identity)
+            .expect("should succeed with Partial");
+
+        assert!(
+            matches!(result, GitIdentityResult::Partial { .. }),
+            "Expected Partial, got {result:?}"
+        );
+        if let GitIdentityResult::Partial {
+            name,
+            email,
+            warnings,
+        } = result
+        {
+            assert!(name.is_none());
+            assert_eq!(email.as_deref(), Some("carol@example.com"));
+            assert!(warnings.iter().any(|w| w.contains("user.name")));
+        }
+    }
+
+    #[test]
+    fn propagates_exec_failure_as_error() {
+        let (_rt, handle) = make_runtime();
+        let client = make_exec_client(1);
+        let identity = HostGitIdentity {
+            name: Some(String::from("Alice")),
+            email: Some(String::from("alice@example.com")),
+        };
+
+        let result = configure_git_identity(&handle, &client, "c5", &identity);
+
+        match result {
+            Err(PodbotError::Container(crate::error::ContainerError::ExecFailed { .. })) => {}
+            other => panic!("Expected Err(ExecFailed), got {other:?}"),
+        }
+    }
+}

--- a/src/engine/connection/git_identity/container_configurator.rs
+++ b/src/engine/connection/git_identity/container_configurator.rs
@@ -9,6 +9,12 @@ use crate::error::PodbotError;
 
 use super::host_reader::HostGitIdentity;
 
+/// Warning message for missing Git user.name configuration.
+const MISSING_NAME_WARNING: &str = "git user.name is not configured on the host";
+
+/// Warning message for missing Git user.email configuration.
+const MISSING_EMAIL_WARNING: &str = "git user.email is not configured on the host";
+
 /// Outcome of configuring Git identity in a container.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum GitIdentityResult {
@@ -35,6 +41,26 @@ pub enum GitIdentityResult {
     },
 }
 
+/// Classifies the completeness of host Git identity.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum IdentityCompleteness {
+    /// Both name and email are present.
+    Complete,
+    /// At least one of name or email is missing.
+    Partial,
+    /// Neither name nor email is present.
+    None,
+}
+
+/// Determines the completeness of the host Git identity.
+const fn classify_identity(identity: &HostGitIdentity) -> IdentityCompleteness {
+    match (&identity.name, &identity.email) {
+        (None, None) => IdentityCompleteness::None,
+        (Some(_), Some(_)) => IdentityCompleteness::Complete,
+        _ => IdentityCompleteness::Partial,
+    }
+}
+
 /// Configure Git identity in a container using host-read values.
 ///
 /// Executes `git config --global user.name` and/or
@@ -51,28 +77,47 @@ pub fn configure_git_identity<C: ContainerExecClient>(
     container_id: &str,
     identity: &HostGitIdentity,
 ) -> Result<GitIdentityResult, PodbotError> {
-    match (&identity.name, &identity.email) {
-        (None, None) => Ok(GitIdentityResult::NoneConfigured {
+    match classify_identity(identity) {
+        IdentityCompleteness::None => Ok(GitIdentityResult::NoneConfigured {
             warnings: vec![
-                String::from("git user.name is not configured on the host"),
-                String::from("git user.email is not configured on the host"),
+                String::from(MISSING_NAME_WARNING),
+                String::from(MISSING_EMAIL_WARNING),
             ],
         }),
-        (Some(name), Some(email)) => {
-            let params = GitConfigParams {
-                runtime,
-                client,
-                container_id,
-            };
-            set_git_config(&params, "user.name", name)?;
-            set_git_config(&params, "user.email", email)?;
-            Ok(GitIdentityResult::Configured {
-                name: name.clone(),
-                email: email.clone(),
-            })
+        IdentityCompleteness::Complete => {
+            configure_complete_identity(runtime, client, container_id, identity)
         }
-        _ => configure_partial_identity(runtime, client, container_id, identity),
+        IdentityCompleteness::Partial => {
+            configure_partial_identity(runtime, client, container_id, identity)
+        }
     }
+}
+
+fn configure_complete_identity<C: ContainerExecClient>(
+    runtime: &tokio::runtime::Handle,
+    client: &C,
+    container_id: &str,
+    identity: &HostGitIdentity,
+) -> Result<GitIdentityResult, PodbotError> {
+    // Pattern match to extract values; this function is only called
+    // when classify_identity returns Complete
+    let (Some(name), Some(email)) = (&identity.name, &identity.email) else {
+        // This should never happen if classify_identity is correct, but we
+        // handle it gracefully by falling back to partial configuration
+        return configure_partial_identity(runtime, client, container_id, identity);
+    };
+
+    let params = GitConfigParams {
+        runtime,
+        client,
+        container_id,
+    };
+    set_git_config(&params, "user.name", name)?;
+    set_git_config(&params, "user.email", email)?;
+    Ok(GitIdentityResult::Configured {
+        name: name.clone(),
+        email: email.clone(),
+    })
 }
 
 fn configure_partial_identity<C: ContainerExecClient>(
@@ -91,13 +136,13 @@ fn configure_partial_identity<C: ContainerExecClient>(
     if let Some(name) = &identity.name {
         set_git_config(&params, "user.name", name)?;
     } else {
-        warnings.push(String::from("git user.name is not configured on the host"));
+        warnings.push(String::from(MISSING_NAME_WARNING));
     }
 
     if let Some(email) = &identity.email {
         set_git_config(&params, "user.email", email)?;
     } else {
-        warnings.push(String::from("git user.email is not configured on the host"));
+        warnings.push(String::from(MISSING_EMAIL_WARNING));
     }
 
     Ok(GitIdentityResult::Partial {

--- a/src/engine/connection/git_identity/container_configurator.rs
+++ b/src/engine/connection/git_identity/container_configurator.rs
@@ -1,0 +1,142 @@
+//! Container-side Git identity configuration.
+//!
+//! Executes `git config --global user.name` and
+//! `git config --global user.email` within a running container using
+//! the injected [`ContainerExecClient`].
+
+use crate::engine::{ContainerExecClient, EngineConnector, ExecMode, ExecRequest};
+use crate::error::PodbotError;
+
+use super::host_reader::HostGitIdentity;
+
+/// Outcome of configuring Git identity in a container.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum GitIdentityResult {
+    /// Both name and email were configured successfully.
+    Configured {
+        /// The configured `user.name`.
+        name: String,
+        /// The configured `user.email`.
+        email: String,
+    },
+    /// Only some identity fields were configured.
+    Partial {
+        /// The configured `user.name`, if set.
+        name: Option<String>,
+        /// The configured `user.email`, if set.
+        email: Option<String>,
+        /// Warning messages for missing fields.
+        warnings: Vec<String>,
+    },
+    /// No identity fields were available on the host.
+    NoneConfigured {
+        /// Warning messages explaining the absence.
+        warnings: Vec<String>,
+    },
+}
+
+/// Configure Git identity in a container using host-read values.
+///
+/// Executes `git config --global user.name` and/or
+/// `git config --global user.email` for each value present in
+/// `identity`. Missing values produce warnings rather than errors.
+///
+/// # Errors
+///
+/// Returns `ContainerError::ExecFailed` if a `git config` command
+/// fails inside the container.
+pub fn configure_git_identity<C: ContainerExecClient>(
+    runtime: &tokio::runtime::Handle,
+    client: &C,
+    container_id: &str,
+    identity: &HostGitIdentity,
+) -> Result<GitIdentityResult, PodbotError> {
+    match (&identity.name, &identity.email) {
+        (None, None) => Ok(GitIdentityResult::NoneConfigured {
+            warnings: vec![
+                String::from("git user.name is not configured on the host"),
+                String::from("git user.email is not configured on the host"),
+            ],
+        }),
+        (Some(name), Some(email)) => {
+            let params = GitConfigParams {
+                runtime,
+                client,
+                container_id,
+            };
+            set_git_config(&params, "user.name", name)?;
+            set_git_config(&params, "user.email", email)?;
+            Ok(GitIdentityResult::Configured {
+                name: name.clone(),
+                email: email.clone(),
+            })
+        }
+        _ => configure_partial_identity(runtime, client, container_id, identity),
+    }
+}
+
+fn configure_partial_identity<C: ContainerExecClient>(
+    runtime: &tokio::runtime::Handle,
+    client: &C,
+    container_id: &str,
+    identity: &HostGitIdentity,
+) -> Result<GitIdentityResult, PodbotError> {
+    let mut warnings = Vec::new();
+    let params = GitConfigParams {
+        runtime,
+        client,
+        container_id,
+    };
+
+    if let Some(name) = &identity.name {
+        set_git_config(&params, "user.name", name)?;
+    } else {
+        warnings.push(String::from("git user.name is not configured on the host"));
+    }
+
+    if let Some(email) = &identity.email {
+        set_git_config(&params, "user.email", email)?;
+    } else {
+        warnings.push(String::from("git user.email is not configured on the host"));
+    }
+
+    Ok(GitIdentityResult::Partial {
+        name: identity.name.clone(),
+        email: identity.email.clone(),
+        warnings,
+    })
+}
+
+struct GitConfigParams<'a, C: ContainerExecClient> {
+    runtime: &'a tokio::runtime::Handle,
+    client: &'a C,
+    container_id: &'a str,
+}
+
+fn set_git_config<C: ContainerExecClient>(
+    params: &GitConfigParams<'_, C>,
+    key: &str,
+    value: &str,
+) -> Result<(), PodbotError> {
+    let command = vec![
+        String::from("git"),
+        String::from("config"),
+        String::from("--global"),
+        String::from(key),
+        String::from(value),
+    ];
+    let request = ExecRequest::new(params.container_id, command, ExecMode::Detached)?;
+    let result = EngineConnector::exec(params.runtime, params.client, &request)?;
+
+    if result.exit_code() != 0 {
+        return Err(super::git_identity_exec_failed(
+            params.container_id,
+            format!(
+                "git config --global {key} failed with exit code {}",
+                result.exit_code()
+            ),
+        ));
+    }
+
+    Ok(())
+}

--- a/src/engine/connection/git_identity/host_reader.rs
+++ b/src/engine/connection/git_identity/host_reader.rs
@@ -1,0 +1,62 @@
+//! Host-side Git identity reading.
+//!
+//! Reads `user.name` and `user.email` from the host Git configuration
+//! by running `git config --get` commands. The command runner is
+//! injected for testability.
+
+use std::io;
+use std::process::Output;
+
+/// Runs a command on the host and returns its output.
+///
+/// This trait abstracts host command execution so tests can inject
+/// mock responses without requiring a real `git` binary.
+pub trait HostCommandRunner {
+    /// Execute `program` with `args` and return the captured output.
+    ///
+    /// # Errors
+    ///
+    /// Returns an I/O error if the command cannot be spawned.
+    fn run_command(&self, program: &str, args: &[&str]) -> io::Result<Output>;
+}
+
+/// Production implementation using `std::process::Command`.
+pub struct SystemCommandRunner;
+
+impl HostCommandRunner for SystemCommandRunner {
+    fn run_command(&self, program: &str, args: &[&str]) -> io::Result<Output> {
+        std::process::Command::new(program).args(args).output()
+    }
+}
+
+/// Identity fields read from the host Git configuration.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HostGitIdentity {
+    /// `user.name` value, if configured on the host.
+    pub name: Option<String>,
+    /// `user.email` value, if configured on the host.
+    pub email: Option<String>,
+}
+
+/// Read Git `user.name` and `user.email` from the host.
+///
+/// Returns `None` values for fields that are not configured rather
+/// than failing. The caller decides how to handle missing fields.
+pub fn read_host_git_identity(runner: &impl HostCommandRunner) -> HostGitIdentity {
+    HostGitIdentity {
+        name: read_git_config_value(runner, "user.name"),
+        email: read_git_config_value(runner, "user.email"),
+    }
+}
+
+fn read_git_config_value(runner: &impl HostCommandRunner, key: &str) -> Option<String> {
+    let output = runner.run_command("git", &["config", "--get", key]).ok()?;
+
+    if !output.status.success() {
+        return None;
+    }
+
+    let value = String::from_utf8_lossy(&output.stdout).trim().to_owned();
+
+    if value.is_empty() { None } else { Some(value) }
+}

--- a/src/engine/connection/git_identity/mod.rs
+++ b/src/engine/connection/git_identity/mod.rs
@@ -1,0 +1,25 @@
+//! Git identity configuration for containers.
+//!
+//! This module reads Git `user.name` and `user.email` from the host
+//! configuration and propagates them into a running container via
+//! `git config --global` exec commands.
+
+mod container_configurator;
+mod host_reader;
+
+pub use container_configurator::{GitIdentityResult, configure_git_identity};
+pub use host_reader::{
+    HostCommandRunner, HostGitIdentity, SystemCommandRunner, read_host_git_identity,
+};
+
+use crate::error::{ContainerError, PodbotError};
+
+fn git_identity_exec_failed(container_id: &str, message: impl Into<String>) -> PodbotError {
+    PodbotError::from(ContainerError::ExecFailed {
+        container_id: String::from(container_id),
+        message: message.into(),
+    })
+}
+
+#[cfg(test)]
+mod tests;

--- a/src/engine/connection/git_identity/mod.rs
+++ b/src/engine/connection/git_identity/mod.rs
@@ -22,4 +22,7 @@ fn git_identity_exec_failed(container_id: &str, message: impl Into<String>) -> P
 }
 
 #[cfg(test)]
+pub(crate) mod test_helpers;
+
+#[cfg(test)]
 mod tests;

--- a/src/engine/connection/git_identity/test_helpers.rs
+++ b/src/engine/connection/git_identity/test_helpers.rs
@@ -1,0 +1,39 @@
+//! Shared test helpers for Git identity unit tests.
+//!
+//! Provides platform-independent `ExitStatus` construction and
+//! `std::process::Output` factories used across `tests.rs` and
+//! `container_configurator.rs` test modules.
+
+use std::process::{ExitStatus, Output};
+
+/// Platform-independent exit status construction.
+#[cfg(unix)]
+pub fn exit_status(code: i32) -> ExitStatus {
+    use std::os::unix::process::ExitStatusExt;
+    ExitStatus::from_raw(code << 8)
+}
+
+/// Platform-independent exit status construction.
+#[cfg(windows)]
+pub fn exit_status(code: i32) -> ExitStatus {
+    use std::os::windows::process::ExitStatusExt;
+    ExitStatus::from_raw(code as u32)
+}
+
+/// Build a successful `Output` with the given stdout content.
+pub fn success_output(stdout: &str) -> Output {
+    Output {
+        status: exit_status(0),
+        stdout: stdout.as_bytes().to_vec(),
+        stderr: Vec::new(),
+    }
+}
+
+/// Build a failed `Output` (exit code 1) with a generic stderr message.
+pub fn failure_output() -> Output {
+    Output {
+        status: exit_status(1),
+        stdout: Vec::new(),
+        stderr: b"error".to_vec(),
+    }
+}

--- a/src/engine/connection/git_identity/tests.rs
+++ b/src/engine/connection/git_identity/tests.rs
@@ -38,22 +38,55 @@ fn failure_output() -> Output {
     }
 }
 
-#[rstest]
-fn read_identity_returns_both_when_configured() {
+fn make_runner(name_raw: Option<&str>, email_raw: Option<&str>) -> MockCommandRunner {
     let mut runner = MockCommandRunner::new();
-    runner
-        .expect_run_command()
-        .withf(|prog, args| prog == "git" && args == ["config", "--get", "user.name"])
-        .returning(|_, _| Ok(success_output("Alice\n")));
-    runner
-        .expect_run_command()
-        .withf(|prog, args| prog == "git" && args == ["config", "--get", "user.email"])
-        .returning(|_, _| Ok(success_output("alice@example.com\n")));
 
+    let name_out = match name_raw {
+        Some(s) => success_output(s),
+        None => failure_output(),
+    };
+    runner
+        .expect_run_command()
+        .withf(|_, args| args.contains(&"user.name"))
+        .returning(move |_, _| Ok(name_out.clone()));
+
+    let email_out = match email_raw {
+        Some(s) => success_output(s),
+        None => failure_output(),
+    };
+    runner
+        .expect_run_command()
+        .withf(|_, args| args.contains(&"user.email"))
+        .returning(move |_, _| Ok(email_out.clone()));
+
+    runner
+}
+
+#[rstest]
+#[case(
+    Some("Alice\n"),
+    Some("alice@example.com\n"),
+    Some("Alice"),
+    Some("alice@example.com")
+)]
+#[case(None, Some("bob@example.com\n"), None, Some("bob@example.com"))]
+#[case(
+    Some("  Alice  \n"),
+    Some("  alice@example.com  \n"),
+    Some("Alice"),
+    Some("alice@example.com")
+)]
+#[case(Some("  \n"), Some("  \n"), None, None)]
+fn read_identity_with_ok_responses(
+    #[case] name_raw: Option<&str>,
+    #[case] email_raw: Option<&str>,
+    #[case] expected_name: Option<&str>,
+    #[case] expected_email: Option<&str>,
+) {
+    let runner = make_runner(name_raw, email_raw);
     let identity = read_host_git_identity(&runner);
-
-    assert_eq!(identity.name.as_deref(), Some("Alice"));
-    assert_eq!(identity.email.as_deref(), Some("alice@example.com"));
+    assert_eq!(identity.name.as_deref(), expected_name);
+    assert_eq!(identity.email.as_deref(), expected_email);
 }
 
 #[rstest]
@@ -62,55 +95,6 @@ fn read_identity_returns_none_when_git_not_installed() {
     runner
         .expect_run_command()
         .returning(|_, _| Err(io::Error::new(io::ErrorKind::NotFound, "not found")));
-
-    let identity = read_host_git_identity(&runner);
-
-    assert!(identity.name.is_none());
-    assert!(identity.email.is_none());
-}
-
-#[rstest]
-fn read_identity_returns_none_for_unconfigured_fields() {
-    let mut runner = MockCommandRunner::new();
-    runner
-        .expect_run_command()
-        .withf(|_, args| args.contains(&"user.name"))
-        .returning(|_, _| Ok(failure_output()));
-    runner
-        .expect_run_command()
-        .withf(|_, args| args.contains(&"user.email"))
-        .returning(|_, _| Ok(success_output("bob@example.com\n")));
-
-    let identity = read_host_git_identity(&runner);
-
-    assert!(identity.name.is_none());
-    assert_eq!(identity.email.as_deref(), Some("bob@example.com"));
-}
-
-#[rstest]
-fn read_identity_trims_whitespace() {
-    let mut runner = MockCommandRunner::new();
-    runner
-        .expect_run_command()
-        .withf(|_, args| args.contains(&"user.name"))
-        .returning(|_, _| Ok(success_output("  Alice  \n")));
-    runner
-        .expect_run_command()
-        .withf(|_, args| args.contains(&"user.email"))
-        .returning(|_, _| Ok(success_output("  alice@example.com  \n")));
-
-    let identity = read_host_git_identity(&runner);
-
-    assert_eq!(identity.name.as_deref(), Some("Alice"));
-    assert_eq!(identity.email.as_deref(), Some("alice@example.com"));
-}
-
-#[rstest]
-fn read_identity_returns_none_for_empty_output() {
-    let mut runner = MockCommandRunner::new();
-    runner
-        .expect_run_command()
-        .returning(|_, _| Ok(success_output("  \n")));
 
     let identity = read_host_git_identity(&runner);
 

--- a/src/engine/connection/git_identity/tests.rs
+++ b/src/engine/connection/git_identity/tests.rs
@@ -41,19 +41,13 @@ fn failure_output() -> Output {
 fn make_runner(name_raw: Option<&str>, email_raw: Option<&str>) -> MockCommandRunner {
     let mut runner = MockCommandRunner::new();
 
-    let name_out = match name_raw {
-        Some(s) => success_output(s),
-        None => failure_output(),
-    };
+    let name_out = name_raw.map_or_else(failure_output, success_output);
     runner
         .expect_run_command()
         .withf(|_, args| args.contains(&"user.name"))
         .returning(move |_, _| Ok(name_out.clone()));
 
-    let email_out = match email_raw {
-        Some(s) => success_output(s),
-        None => failure_output(),
-    };
+    let email_out = email_raw.map_or_else(failure_output, success_output);
     runner
         .expect_run_command()
         .withf(|_, args| args.contains(&"user.email"))

--- a/src/engine/connection/git_identity/tests.rs
+++ b/src/engine/connection/git_identity/tests.rs
@@ -1,0 +1,124 @@
+//! Unit tests for Git identity configuration.
+
+use std::io;
+use std::os::unix::process::ExitStatusExt;
+use std::process::{ExitStatus, Output};
+
+use mockall::mock;
+use rstest::rstest;
+
+use super::host_reader::{HostCommandRunner, read_host_git_identity};
+
+// -- Host reader tests --
+
+mock! {
+    CommandRunner {}
+    impl HostCommandRunner for CommandRunner {
+        fn run_command<'a>(
+            &self,
+            program: &'a str,
+            args: &'a [&'a str],
+        ) -> io::Result<Output>;
+    }
+}
+
+fn success_output(stdout: &str) -> Output {
+    Output {
+        status: ExitStatus::from_raw(0),
+        stdout: stdout.as_bytes().to_vec(),
+        stderr: Vec::new(),
+    }
+}
+
+fn failure_output() -> Output {
+    Output {
+        status: ExitStatus::from_raw(256), // exit code 1
+        stdout: Vec::new(),
+        stderr: b"error".to_vec(),
+    }
+}
+
+#[rstest]
+fn read_identity_returns_both_when_configured() {
+    let mut runner = MockCommandRunner::new();
+    runner
+        .expect_run_command()
+        .withf(|prog, args| prog == "git" && args == ["config", "--get", "user.name"])
+        .returning(|_, _| Ok(success_output("Alice\n")));
+    runner
+        .expect_run_command()
+        .withf(|prog, args| prog == "git" && args == ["config", "--get", "user.email"])
+        .returning(|_, _| Ok(success_output("alice@example.com\n")));
+
+    let identity = read_host_git_identity(&runner);
+
+    assert_eq!(identity.name.as_deref(), Some("Alice"));
+    assert_eq!(identity.email.as_deref(), Some("alice@example.com"));
+}
+
+#[rstest]
+fn read_identity_returns_none_when_git_not_installed() {
+    let mut runner = MockCommandRunner::new();
+    runner
+        .expect_run_command()
+        .returning(|_, _| Err(io::Error::new(io::ErrorKind::NotFound, "not found")));
+
+    let identity = read_host_git_identity(&runner);
+
+    assert!(identity.name.is_none());
+    assert!(identity.email.is_none());
+}
+
+#[rstest]
+fn read_identity_returns_none_for_unconfigured_fields() {
+    let mut runner = MockCommandRunner::new();
+    runner
+        .expect_run_command()
+        .withf(|_, args| args.contains(&"user.name"))
+        .returning(|_, _| Ok(failure_output()));
+    runner
+        .expect_run_command()
+        .withf(|_, args| args.contains(&"user.email"))
+        .returning(|_, _| Ok(success_output("bob@example.com\n")));
+
+    let identity = read_host_git_identity(&runner);
+
+    assert!(identity.name.is_none());
+    assert_eq!(identity.email.as_deref(), Some("bob@example.com"));
+}
+
+#[rstest]
+fn read_identity_trims_whitespace() {
+    let mut runner = MockCommandRunner::new();
+    runner
+        .expect_run_command()
+        .withf(|_, args| args.contains(&"user.name"))
+        .returning(|_, _| Ok(success_output("  Alice  \n")));
+    runner
+        .expect_run_command()
+        .withf(|_, args| args.contains(&"user.email"))
+        .returning(|_, _| Ok(success_output("  alice@example.com  \n")));
+
+    let identity = read_host_git_identity(&runner);
+
+    assert_eq!(identity.name.as_deref(), Some("Alice"));
+    assert_eq!(identity.email.as_deref(), Some("alice@example.com"));
+}
+
+#[rstest]
+fn read_identity_returns_none_for_empty_output() {
+    let mut runner = MockCommandRunner::new();
+    runner
+        .expect_run_command()
+        .returning(|_, _| Ok(success_output("  \n")));
+
+    let identity = read_host_git_identity(&runner);
+
+    assert!(identity.name.is_none());
+    assert!(identity.email.is_none());
+}
+
+// Note: Container configurator tests use mock ContainerExecClient
+// and are in the BDD test suite (Stage C) for full integration
+// coverage. Additional unit tests for set_git_config error paths
+// are here.

--- a/src/engine/connection/git_identity/tests.rs
+++ b/src/engine/connection/git_identity/tests.rs
@@ -1,7 +1,6 @@
 //! Unit tests for Git identity configuration.
 
 use std::io;
-use std::os::unix::process::ExitStatusExt;
 use std::process::{ExitStatus, Output};
 
 use mockall::mock;
@@ -22,9 +21,22 @@ mock! {
     }
 }
 
+/// Create an exit status with the given exit code in a platform-independent way.
+#[cfg(unix)]
+fn exit_status(code: i32) -> ExitStatus {
+    use std::os::unix::process::ExitStatusExt;
+    ExitStatus::from_raw(code << 8)
+}
+
+#[cfg(windows)]
+fn exit_status(code: i32) -> ExitStatus {
+    use std::os::windows::process::ExitStatusExt;
+    ExitStatus::from_raw(code as u32)
+}
+
 fn success_output(stdout: &str) -> Output {
     Output {
-        status: ExitStatus::from_raw(0),
+        status: exit_status(0),
         stdout: stdout.as_bytes().to_vec(),
         stderr: Vec::new(),
     }
@@ -32,7 +44,7 @@ fn success_output(stdout: &str) -> Output {
 
 fn failure_output() -> Output {
     Output {
-        status: ExitStatus::from_raw(256), // exit code 1
+        status: exit_status(1),
         stdout: Vec::new(),
         stderr: b"error".to_vec(),
     }
@@ -63,6 +75,7 @@ fn make_runner(name_raw: Option<&str>, email_raw: Option<&str>) -> MockCommandRu
     Some("Alice"),
     Some("alice@example.com")
 )]
+#[case(Some("Alice\n"), None, Some("Alice"), None)]
 #[case(None, Some("bob@example.com\n"), None, Some("bob@example.com"))]
 #[case(
     Some("  Alice  \n"),

--- a/src/engine/connection/git_identity/tests.rs
+++ b/src/engine/connection/git_identity/tests.rs
@@ -1,12 +1,13 @@
 //! Unit tests for Git identity configuration.
 
 use std::io;
-use std::process::{ExitStatus, Output};
+use std::process::Output;
 
 use mockall::mock;
 use rstest::rstest;
 
 use super::host_reader::{HostCommandRunner, read_host_git_identity};
+use super::test_helpers::{failure_output, success_output};
 
 // -- Host reader tests --
 
@@ -18,35 +19,6 @@ mock! {
             program: &'a str,
             args: &'a [&'a str],
         ) -> io::Result<Output>;
-    }
-}
-
-/// Create an exit status with the given exit code in a platform-independent way.
-#[cfg(unix)]
-fn exit_status(code: i32) -> ExitStatus {
-    use std::os::unix::process::ExitStatusExt;
-    ExitStatus::from_raw(code << 8)
-}
-
-#[cfg(windows)]
-fn exit_status(code: i32) -> ExitStatus {
-    use std::os::windows::process::ExitStatusExt;
-    ExitStatus::from_raw(code as u32)
-}
-
-fn success_output(stdout: &str) -> Output {
-    Output {
-        status: exit_status(0),
-        stdout: stdout.as_bytes().to_vec(),
-        stderr: Vec::new(),
-    }
-}
-
-fn failure_output() -> Output {
-    Output {
-        status: exit_status(1),
-        stdout: Vec::new(),
-        stderr: b"error".to_vec(),
     }
 }
 

--- a/src/engine/connection/mod.rs
+++ b/src/engine/connection/mod.rs
@@ -2,7 +2,9 @@
 //!
 //! This module provides functionality to resolve container engine socket endpoints
 //! from multiple sources (environment variables, configuration, platform defaults)
-//! and establish connections using the `Bollard` library.
+//! and establish connections using the `Bollard` library. It also re-exports Git
+//! identity configuration utilities for propagating host Git credentials into
+//! containers.
 
 mod create_container;
 mod error_classification;

--- a/src/engine/connection/mod.rs
+++ b/src/engine/connection/mod.rs
@@ -7,6 +7,7 @@
 mod create_container;
 mod error_classification;
 mod exec;
+mod git_identity;
 mod health_check;
 mod upload_credentials;
 
@@ -24,6 +25,10 @@ pub use create_container::{
 pub use exec::{
     ContainerExecClient, CreateExecFuture, ExecMode, ExecRequest, ExecResult, InspectExecFuture,
     ResizeExecFuture, StartExecFuture,
+};
+pub use git_identity::{
+    GitIdentityResult, HostCommandRunner, HostGitIdentity, SystemCommandRunner,
+    configure_git_identity, read_host_git_identity,
 };
 pub use upload_credentials::{
     ContainerUploader, CredentialUploadRequest, CredentialUploadResult, UploadToContainerFuture,

--- a/src/engine/connection/mod.rs
+++ b/src/engine/connection/mod.rs
@@ -357,4 +357,7 @@ impl EngineConnector {
 }
 
 #[cfg(test)]
+pub(crate) use git_identity::test_helpers;
+
+#[cfg(test)]
 mod tests;

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -22,3 +22,6 @@ pub use connection::{
     SocketResolver, StartExecFuture, SystemCommandRunner, UploadToContainerFuture,
     configure_git_identity, read_host_git_identity,
 };
+
+#[cfg(test)]
+pub(crate) use connection::test_helpers;

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -17,6 +17,8 @@ mod connection;
 pub use connection::{
     ContainerCreator, ContainerExecClient, ContainerSecurityOptions, ContainerUploader,
     CreateContainerFuture, CreateContainerRequest, CreateExecFuture, CredentialUploadRequest,
-    CredentialUploadResult, EngineConnector, ExecMode, ExecRequest, ExecResult, InspectExecFuture,
-    ResizeExecFuture, SelinuxLabelMode, SocketResolver, StartExecFuture, UploadToContainerFuture,
+    CredentialUploadResult, EngineConnector, ExecMode, ExecRequest, ExecResult, GitIdentityResult,
+    HostCommandRunner, HostGitIdentity, InspectExecFuture, ResizeExecFuture, SelinuxLabelMode,
+    SocketResolver, StartExecFuture, SystemCommandRunner, UploadToContainerFuture,
+    configure_git_identity, read_host_git_identity,
 };

--- a/tests/bdd_git_identity.rs
+++ b/tests/bdd_git_identity.rs
@@ -1,0 +1,46 @@
+//! Behavioural tests for Git identity configuration.
+
+mod bdd_git_identity_helpers;
+
+pub use bdd_git_identity_helpers::{GitIdentityState, git_identity_state};
+use rstest_bdd_macros::scenario;
+
+#[scenario(
+    path = "tests/features/git_identity.feature",
+    name = "Both name and email are configured"
+)]
+fn both_name_and_email_are_configured(git_identity_state: GitIdentityState) {
+    let _ = git_identity_state;
+}
+
+#[scenario(
+    path = "tests/features/git_identity.feature",
+    name = "Only name is configured on the host"
+)]
+fn only_name_is_configured_on_the_host(git_identity_state: GitIdentityState) {
+    let _ = git_identity_state;
+}
+
+#[scenario(
+    path = "tests/features/git_identity.feature",
+    name = "Only email is configured on the host"
+)]
+fn only_email_is_configured_on_the_host(git_identity_state: GitIdentityState) {
+    let _ = git_identity_state;
+}
+
+#[scenario(
+    path = "tests/features/git_identity.feature",
+    name = "Neither name nor email is configured"
+)]
+fn neither_name_nor_email_is_configured(git_identity_state: GitIdentityState) {
+    let _ = git_identity_state;
+}
+
+#[scenario(
+    path = "tests/features/git_identity.feature",
+    name = "Container exec failure propagates as error"
+)]
+fn container_exec_failure_propagates_as_error(git_identity_state: GitIdentityState) {
+    let _ = git_identity_state;
+}

--- a/tests/bdd_git_identity.rs
+++ b/tests/bdd_git_identity.rs
@@ -39,6 +39,14 @@ fn neither_name_nor_email_is_configured(git_identity_state: GitIdentityState) {
 
 #[scenario(
     path = "tests/features/git_identity.feature",
+    name = "Multi-word name is configured"
+)]
+fn multi_word_name_is_configured(git_identity_state: GitIdentityState) {
+    let _ = git_identity_state;
+}
+
+#[scenario(
+    path = "tests/features/git_identity.feature",
     name = "Container exec failure propagates as error"
 )]
 fn container_exec_failure_propagates_as_error(git_identity_state: GitIdentityState) {

--- a/tests/bdd_git_identity_helpers/assertions.rs
+++ b/tests/bdd_git_identity_helpers/assertions.rs
@@ -14,7 +14,7 @@ fn convert_outcome(
 ) -> Result<GitIdentityResult, String> {
     match outcome {
         Ok(r) => Ok(r.clone()),
-        Err(e) => Err(format!("{e}")),
+        Err(e) => Err(e.to_string()),
     }
 }
 
@@ -104,14 +104,17 @@ fn git_identity_result_is_none_configured(git_identity_state: &GitIdentityState)
 
 /// Checks configured name matches expected value.
 /// "absent" is treated specially to check for None.
-#[then("configured name is {word}")]
-fn configured_name_is(git_identity_state: &GitIdentityState, word: String) -> StepResult<()> {
+#[then("configured name is {string}")]
+fn configured_name_is(git_identity_state: &GitIdentityState, string: String) -> StepResult<()> {
+    // rstest-bdd {string} captures include the surrounding quotes, so strip them
+    let value = string.trim_matches('"');
+
     git_identity_state
         .outcome
         .with_ref(|outcome| {
             let converted = convert_outcome(outcome);
 
-            if word == "absent" {
+            if value == "absent" {
                 assert_field_absent(
                     &converted,
                     |r| {
@@ -131,7 +134,7 @@ fn configured_name_is(git_identity_state: &GitIdentityState, word: String) -> St
                         GitIdentityResult::Partial { name: Some(n), .. } => Some(n.as_str()),
                         _ => None,
                     },
-                    &word,
+                    value,
                     "name",
                 )
             }
@@ -141,14 +144,17 @@ fn configured_name_is(git_identity_state: &GitIdentityState, word: String) -> St
 
 /// Checks configured email matches expected value.
 /// "absent" is treated specially to check for None.
-#[then("configured email is {word}")]
-fn configured_email_is(git_identity_state: &GitIdentityState, word: String) -> StepResult<()> {
+#[then("configured email is {string}")]
+fn configured_email_is(git_identity_state: &GitIdentityState, string: String) -> StepResult<()> {
+    // rstest-bdd {string} captures include the surrounding quotes, so strip them
+    let value = string.trim_matches('"');
+
     git_identity_state
         .outcome
         .with_ref(|outcome| {
             let converted = convert_outcome(outcome);
 
-            if word == "absent" {
+            if value == "absent" {
                 assert_field_absent(
                     &converted,
                     |r| {
@@ -168,7 +174,7 @@ fn configured_email_is(git_identity_state: &GitIdentityState, word: String) -> S
                         GitIdentityResult::Partial { email: Some(e), .. } => Some(e.as_str()),
                         _ => None,
                     },
-                    &word,
+                    value,
                     "email",
                 )
             }

--- a/tests/bdd_git_identity_helpers/assertions.rs
+++ b/tests/bdd_git_identity_helpers/assertions.rs
@@ -1,0 +1,191 @@
+//! Then step definitions for Git identity behavioural scenarios.
+
+use podbot::engine::GitIdentityResult;
+use rstest_bdd_macros::then;
+
+use super::state::{GitIdentityState, StepResult};
+
+#[then("git identity result is configured")]
+fn git_identity_result_is_configured(git_identity_state: &GitIdentityState) -> StepResult<()> {
+    let outcome = git_identity_state
+        .outcome
+        .get()
+        .ok_or_else(|| String::from("outcome not set"))?;
+
+    match outcome {
+        Ok(GitIdentityResult::Configured { .. }) => Ok(()),
+        Ok(other) => Err(format!("Expected Configured, got {other:?}")),
+        Err(e) => Err(format!("Expected success, got error: {e}")),
+    }
+}
+
+#[then("git identity result is partial")]
+fn git_identity_result_is_partial(git_identity_state: &GitIdentityState) -> StepResult<()> {
+    let outcome = git_identity_state
+        .outcome
+        .get()
+        .ok_or_else(|| String::from("outcome not set"))?;
+
+    match outcome {
+        Ok(GitIdentityResult::Partial { .. }) => Ok(()),
+        Ok(other) => Err(format!("Expected Partial, got {other:?}")),
+        Err(e) => Err(format!("Expected success, got error: {e}")),
+    }
+}
+
+#[then("git identity result is none configured")]
+fn git_identity_result_is_none_configured(git_identity_state: &GitIdentityState) -> StepResult<()> {
+    let outcome = git_identity_state
+        .outcome
+        .get()
+        .ok_or_else(|| String::from("outcome not set"))?;
+
+    match outcome {
+        Ok(GitIdentityResult::NoneConfigured { .. }) => Ok(()),
+        Ok(other) => Err(format!("Expected NoneConfigured, got {other:?}")),
+        Err(e) => Err(format!("Expected success, got error: {e}")),
+    }
+}
+
+#[then("configured name is {name}")]
+fn configured_name_is_name(git_identity_state: &GitIdentityState, name: String) -> StepResult<()> {
+    let outcome = git_identity_state
+        .outcome
+        .get()
+        .ok_or_else(|| String::from("outcome not set"))?;
+
+    match outcome {
+        Ok(GitIdentityResult::Configured {
+            name: actual_name, ..
+        }) => {
+            if actual_name == &name {
+                Ok(())
+            } else {
+                Err(format!("Expected name '{name}', got '{actual_name}'"))
+            }
+        }
+        Ok(GitIdentityResult::Partial {
+            name: Some(actual_name),
+            ..
+        }) => {
+            if actual_name == &name {
+                Ok(())
+            } else {
+                Err(format!("Expected name '{name}', got '{actual_name}'"))
+            }
+        }
+        Ok(other) => Err(format!("Cannot check name on result: {other:?}")),
+        Err(e) => Err(format!("Expected success, got error: {e}")),
+    }
+}
+
+#[then("configured email is {email}")]
+fn configured_email_is_email(
+    git_identity_state: &GitIdentityState,
+    email: String,
+) -> StepResult<()> {
+    let outcome = git_identity_state
+        .outcome
+        .get()
+        .ok_or_else(|| String::from("outcome not set"))?;
+
+    match outcome {
+        Ok(GitIdentityResult::Configured {
+            email: actual_email,
+            ..
+        }) => {
+            if actual_email == &email {
+                Ok(())
+            } else {
+                Err(format!("Expected email '{email}', got '{actual_email}'"))
+            }
+        }
+        Ok(GitIdentityResult::Partial {
+            email: Some(actual_email),
+            ..
+        }) => {
+            if actual_email == &email {
+                Ok(())
+            } else {
+                Err(format!("Expected email '{email}', got '{actual_email}'"))
+            }
+        }
+        Ok(other) => Err(format!("Cannot check email on result: {other:?}")),
+        Err(e) => Err(format!("Expected success, got error: {e}")),
+    }
+}
+
+#[then("configured name is absent")]
+fn configured_name_is_absent(git_identity_state: &GitIdentityState) -> StepResult<()> {
+    let outcome = git_identity_state
+        .outcome
+        .get()
+        .ok_or_else(|| String::from("outcome not set"))?;
+
+    match outcome {
+        Ok(GitIdentityResult::Partial { name: None, .. }) => Ok(()),
+        Ok(GitIdentityResult::NoneConfigured { .. }) => Ok(()),
+        Ok(other) => Err(format!("Expected absent name, got {other:?}")),
+        Err(e) => Err(format!("Expected success, got error: {e}")),
+    }
+}
+
+#[then("configured email is absent")]
+fn configured_email_is_absent(git_identity_state: &GitIdentityState) -> StepResult<()> {
+    let outcome = git_identity_state
+        .outcome
+        .get()
+        .ok_or_else(|| String::from("outcome not set"))?;
+
+    match outcome {
+        Ok(GitIdentityResult::Partial { email: None, .. }) => Ok(()),
+        Ok(GitIdentityResult::NoneConfigured { .. }) => Ok(()),
+        Ok(other) => Err(format!("Expected absent email, got {other:?}")),
+        Err(e) => Err(format!("Expected success, got error: {e}")),
+    }
+}
+
+#[then("warnings include {warning}")]
+fn warnings_include_warning(
+    git_identity_state: &GitIdentityState,
+    warning: String,
+) -> StepResult<()> {
+    let outcome = git_identity_state
+        .outcome
+        .get()
+        .ok_or_else(|| String::from("outcome not set"))?;
+
+    let warnings = match outcome {
+        Ok(GitIdentityResult::Partial { warnings, .. }) => warnings,
+        Ok(GitIdentityResult::NoneConfigured { warnings }) => warnings,
+        Ok(other) => {
+            return Err(format!(
+                "Expected result with warnings, got {other:?}"
+            ))
+        }
+        Err(e) => return Err(format!("Expected success, got error: {e}")),
+    };
+
+    if warnings.contains(&warning) {
+        Ok(())
+    } else {
+        Err(format!(
+            "Expected warning '{warning}' not found in {warnings:?}"
+        ))
+    }
+}
+
+#[then("git identity configuration fails with an exec error")]
+fn git_identity_configuration_fails_with_exec_error(
+    git_identity_state: &GitIdentityState,
+) -> StepResult<()> {
+    let outcome = git_identity_state
+        .outcome
+        .get()
+        .ok_or_else(|| String::from("outcome not set"))?;
+
+    match outcome {
+        Err(_) => Ok(()),
+        Ok(result) => Err(format!("Expected error, got success: {result:?}")),
+    }
+}

--- a/tests/bdd_git_identity_helpers/assertions.rs
+++ b/tests/bdd_git_identity_helpers/assertions.rs
@@ -214,11 +214,11 @@ fn warnings_include_warning(
                 Err(e) => return Err(format!("Expected success, got error: {e}")),
             };
 
-            if warnings.contains(&warning) {
+            if warnings.iter().any(|w| w.contains(&warning)) {
                 Ok(())
             } else {
                 Err(format!(
-                    "Expected warning '{warning}' not found in {warnings:?}"
+                    "No warning containing '{warning}' found in {warnings:?}"
                 ))
             }
         })

--- a/tests/bdd_git_identity_helpers/assertions.rs
+++ b/tests/bdd_git_identity_helpers/assertions.rs
@@ -1,82 +1,104 @@
 //! Then step definitions for Git identity behavioural scenarios.
 
 use podbot::engine::GitIdentityResult;
+use podbot::error::PodbotError;
 use rstest_bdd_macros::then;
 
 use super::state::{GitIdentityState, StepResult};
 
-#[then("git identity result is configured")]
-fn git_identity_result_is_configured(git_identity_state: &GitIdentityState) -> StepResult<()> {
-    let outcome = git_identity_state
+fn get_outcome(state: &GitIdentityState) -> StepResult<Result<GitIdentityResult, String>> {
+    let result = state
         .outcome
         .get()
         .ok_or_else(|| String::from("outcome not set"))?;
 
+    match result {
+        Ok(identity_result) => Ok(Ok(identity_result)),
+        Err(e) => Ok(Err(format!("{e}"))),
+    }
+}
+
+fn assert_ok_variant(
+    outcome: &Result<GitIdentityResult, String>,
+    check: impl Fn(&GitIdentityResult) -> bool,
+    expected: &str,
+) -> StepResult<()> {
     match outcome {
-        Ok(GitIdentityResult::Configured { .. }) => Ok(()),
-        Ok(other) => Err(format!("Expected Configured, got {other:?}")),
+        Ok(r) if check(r) => Ok(()),
+        Ok(other) => Err(format!("Expected {expected}, got {other:?}")),
         Err(e) => Err(format!("Expected success, got error: {e}")),
     }
+}
+
+fn assert_field_value<'a>(
+    outcome: &'a Result<GitIdentityResult, String>,
+    extractor: impl Fn(&'a GitIdentityResult) -> Option<&'a str>,
+    expected: &str,
+    field_name: &str,
+) -> StepResult<()> {
+    match outcome {
+        Ok(result) => match extractor(result) {
+            Some(actual) if actual == expected => Ok(()),
+            Some(actual) => Err(format!(
+                "Expected {field_name} '{expected}', got '{actual}'"
+            )),
+            None => Err(format!("Cannot check {field_name} on result: {result:?}")),
+        },
+        Err(e) => Err(format!("Expected success, got error: {e}")),
+    }
+}
+
+fn assert_field_absent(
+    outcome: &Result<GitIdentityResult, String>,
+    field_present: impl Fn(&GitIdentityResult) -> bool,
+    field_name: &str,
+) -> StepResult<()> {
+    match outcome {
+        Ok(r) if !field_present(r) => Ok(()),
+        Ok(other) => Err(format!("Expected absent {field_name}, got {other:?}")),
+        Err(e) => Err(format!("Expected success, got error: {e}")),
+    }
+}
+
+#[then("git identity result is configured")]
+fn git_identity_result_is_configured(git_identity_state: &GitIdentityState) -> StepResult<()> {
+    assert_ok_variant(
+        get_outcome(git_identity_state)?,
+        |r| matches!(r, GitIdentityResult::Configured { .. }),
+        "Configured",
+    )
 }
 
 #[then("git identity result is partial")]
 fn git_identity_result_is_partial(git_identity_state: &GitIdentityState) -> StepResult<()> {
-    let outcome = git_identity_state
-        .outcome
-        .get()
-        .ok_or_else(|| String::from("outcome not set"))?;
-
-    match outcome {
-        Ok(GitIdentityResult::Partial { .. }) => Ok(()),
-        Ok(other) => Err(format!("Expected Partial, got {other:?}")),
-        Err(e) => Err(format!("Expected success, got error: {e}")),
-    }
+    assert_ok_variant(
+        get_outcome(git_identity_state)?,
+        |r| matches!(r, GitIdentityResult::Partial { .. }),
+        "Partial",
+    )
 }
 
 #[then("git identity result is none configured")]
 fn git_identity_result_is_none_configured(git_identity_state: &GitIdentityState) -> StepResult<()> {
-    let outcome = git_identity_state
-        .outcome
-        .get()
-        .ok_or_else(|| String::from("outcome not set"))?;
-
-    match outcome {
-        Ok(GitIdentityResult::NoneConfigured { .. }) => Ok(()),
-        Ok(other) => Err(format!("Expected NoneConfigured, got {other:?}")),
-        Err(e) => Err(format!("Expected success, got error: {e}")),
-    }
+    assert_ok_variant(
+        get_outcome(git_identity_state)?,
+        |r| matches!(r, GitIdentityResult::NoneConfigured { .. }),
+        "NoneConfigured",
+    )
 }
 
 #[then("configured name is {name}")]
 fn configured_name_is_name(git_identity_state: &GitIdentityState, name: String) -> StepResult<()> {
-    let outcome = git_identity_state
-        .outcome
-        .get()
-        .ok_or_else(|| String::from("outcome not set"))?;
-
-    match outcome {
-        Ok(GitIdentityResult::Configured {
-            name: actual_name, ..
-        }) => {
-            if actual_name == &name {
-                Ok(())
-            } else {
-                Err(format!("Expected name '{name}', got '{actual_name}'"))
-            }
-        }
-        Ok(GitIdentityResult::Partial {
-            name: Some(actual_name),
-            ..
-        }) => {
-            if actual_name == &name {
-                Ok(())
-            } else {
-                Err(format!("Expected name '{name}', got '{actual_name}'"))
-            }
-        }
-        Ok(other) => Err(format!("Cannot check name on result: {other:?}")),
-        Err(e) => Err(format!("Expected success, got error: {e}")),
-    }
+    assert_field_value(
+        get_outcome(git_identity_state)?,
+        |r| match r {
+            GitIdentityResult::Configured { name, .. } => Some(name.as_str()),
+            GitIdentityResult::Partial { name: Some(n), .. } => Some(n.as_str()),
+            _ => None,
+        },
+        &name,
+        "name",
+    )
 }
 
 #[then("configured email is {email}")]
@@ -84,65 +106,46 @@ fn configured_email_is_email(
     git_identity_state: &GitIdentityState,
     email: String,
 ) -> StepResult<()> {
-    let outcome = git_identity_state
-        .outcome
-        .get()
-        .ok_or_else(|| String::from("outcome not set"))?;
-
-    match outcome {
-        Ok(GitIdentityResult::Configured {
-            email: actual_email,
-            ..
-        }) => {
-            if actual_email == &email {
-                Ok(())
-            } else {
-                Err(format!("Expected email '{email}', got '{actual_email}'"))
-            }
-        }
-        Ok(GitIdentityResult::Partial {
-            email: Some(actual_email),
-            ..
-        }) => {
-            if actual_email == &email {
-                Ok(())
-            } else {
-                Err(format!("Expected email '{email}', got '{actual_email}'"))
-            }
-        }
-        Ok(other) => Err(format!("Cannot check email on result: {other:?}")),
-        Err(e) => Err(format!("Expected success, got error: {e}")),
-    }
+    assert_field_value(
+        get_outcome(git_identity_state)?,
+        |r| match r {
+            GitIdentityResult::Configured { email, .. } => Some(email.as_str()),
+            GitIdentityResult::Partial { email: Some(e), .. } => Some(e.as_str()),
+            _ => None,
+        },
+        &email,
+        "email",
+    )
 }
 
 #[then("configured name is absent")]
 fn configured_name_is_absent(git_identity_state: &GitIdentityState) -> StepResult<()> {
-    let outcome = git_identity_state
-        .outcome
-        .get()
-        .ok_or_else(|| String::from("outcome not set"))?;
-
-    match outcome {
-        Ok(GitIdentityResult::Partial { name: None, .. }) => Ok(()),
-        Ok(GitIdentityResult::NoneConfigured { .. }) => Ok(()),
-        Ok(other) => Err(format!("Expected absent name, got {other:?}")),
-        Err(e) => Err(format!("Expected success, got error: {e}")),
-    }
+    assert_field_absent(
+        get_outcome(git_identity_state)?,
+        |r| {
+            matches!(
+                r,
+                GitIdentityResult::Configured { .. }
+                    | GitIdentityResult::Partial { name: Some(_), .. }
+            )
+        },
+        "name",
+    )
 }
 
 #[then("configured email is absent")]
 fn configured_email_is_absent(git_identity_state: &GitIdentityState) -> StepResult<()> {
-    let outcome = git_identity_state
-        .outcome
-        .get()
-        .ok_or_else(|| String::from("outcome not set"))?;
-
-    match outcome {
-        Ok(GitIdentityResult::Partial { email: None, .. }) => Ok(()),
-        Ok(GitIdentityResult::NoneConfigured { .. }) => Ok(()),
-        Ok(other) => Err(format!("Expected absent email, got {other:?}")),
-        Err(e) => Err(format!("Expected success, got error: {e}")),
-    }
+    assert_field_absent(
+        get_outcome(git_identity_state)?,
+        |r| {
+            matches!(
+                r,
+                GitIdentityResult::Configured { .. }
+                    | GitIdentityResult::Partial { email: Some(_), .. }
+            )
+        },
+        "email",
+    )
 }
 
 #[then("warnings include {warning}")]
@@ -150,19 +153,10 @@ fn warnings_include_warning(
     git_identity_state: &GitIdentityState,
     warning: String,
 ) -> StepResult<()> {
-    let outcome = git_identity_state
-        .outcome
-        .get()
-        .ok_or_else(|| String::from("outcome not set"))?;
-
-    let warnings = match outcome {
+    let warnings = match get_outcome(git_identity_state)? {
         Ok(GitIdentityResult::Partial { warnings, .. }) => warnings,
         Ok(GitIdentityResult::NoneConfigured { warnings }) => warnings,
-        Ok(other) => {
-            return Err(format!(
-                "Expected result with warnings, got {other:?}"
-            ))
-        }
+        Ok(other) => return Err(format!("Expected result with warnings, got {other:?}")),
         Err(e) => return Err(format!("Expected success, got error: {e}")),
     };
 
@@ -179,12 +173,7 @@ fn warnings_include_warning(
 fn git_identity_configuration_fails_with_exec_error(
     git_identity_state: &GitIdentityState,
 ) -> StepResult<()> {
-    let outcome = git_identity_state
-        .outcome
-        .get()
-        .ok_or_else(|| String::from("outcome not set"))?;
-
-    match outcome {
+    match get_outcome(git_identity_state)? {
         Err(_) => Ok(()),
         Ok(result) => Err(format!("Expected error, got success: {result:?}")),
     }

--- a/tests/bdd_git_identity_helpers/assertions.rs
+++ b/tests/bdd_git_identity_helpers/assertions.rs
@@ -1,22 +1,9 @@
 //! Then step definitions for Git identity behavioural scenarios.
 
 use podbot::engine::GitIdentityResult;
-use podbot::error::PodbotError;
 use rstest_bdd_macros::then;
 
 use super::state::{GitIdentityState, StepResult};
-
-fn get_outcome(state: &GitIdentityState) -> StepResult<Result<GitIdentityResult, String>> {
-    let result = state
-        .outcome
-        .get()
-        .ok_or_else(|| String::from("outcome not set"))?;
-
-    match result {
-        Ok(identity_result) => Ok(Ok(identity_result)),
-        Err(e) => Ok(Err(format!("{e}"))),
-    }
-}
 
 fn assert_ok_variant(
     outcome: &Result<GitIdentityResult, String>,
@@ -62,119 +49,182 @@ fn assert_field_absent(
 
 #[then("git identity result is configured")]
 fn git_identity_result_is_configured(git_identity_state: &GitIdentityState) -> StepResult<()> {
-    assert_ok_variant(
-        get_outcome(git_identity_state)?,
-        |r| matches!(r, GitIdentityResult::Configured { .. }),
-        "Configured",
-    )
+    git_identity_state
+        .outcome
+        .with_ref(|outcome| {
+            let converted = match outcome {
+                Ok(r) => Ok(r.clone()),
+                Err(e) => Err(format!("{e}")),
+            };
+            assert_ok_variant(
+                &converted,
+                |r| matches!(r, GitIdentityResult::Configured { .. }),
+                "Configured",
+            )
+        })
+        .ok_or_else(|| String::from("outcome not set"))?
 }
 
 #[then("git identity result is partial")]
 fn git_identity_result_is_partial(git_identity_state: &GitIdentityState) -> StepResult<()> {
-    assert_ok_variant(
-        get_outcome(git_identity_state)?,
-        |r| matches!(r, GitIdentityResult::Partial { .. }),
-        "Partial",
-    )
+    git_identity_state
+        .outcome
+        .with_ref(|outcome| {
+            let converted = match outcome {
+                Ok(r) => Ok(r.clone()),
+                Err(e) => Err(format!("{e}")),
+            };
+            assert_ok_variant(
+                &converted,
+                |r| matches!(r, GitIdentityResult::Partial { .. }),
+                "Partial",
+            )
+        })
+        .ok_or_else(|| String::from("outcome not set"))?
 }
 
 #[then("git identity result is none configured")]
 fn git_identity_result_is_none_configured(git_identity_state: &GitIdentityState) -> StepResult<()> {
-    assert_ok_variant(
-        get_outcome(git_identity_state)?,
-        |r| matches!(r, GitIdentityResult::NoneConfigured { .. }),
-        "NoneConfigured",
-    )
-}
-
-#[then("configured name is {name}")]
-fn configured_name_is_name(git_identity_state: &GitIdentityState, name: String) -> StepResult<()> {
-    assert_field_value(
-        get_outcome(git_identity_state)?,
-        |r| match r {
-            GitIdentityResult::Configured { name, .. } => Some(name.as_str()),
-            GitIdentityResult::Partial { name: Some(n), .. } => Some(n.as_str()),
-            _ => None,
-        },
-        &name,
-        "name",
-    )
-}
-
-#[then("configured email is {email}")]
-fn configured_email_is_email(
-    git_identity_state: &GitIdentityState,
-    email: String,
-) -> StepResult<()> {
-    assert_field_value(
-        get_outcome(git_identity_state)?,
-        |r| match r {
-            GitIdentityResult::Configured { email, .. } => Some(email.as_str()),
-            GitIdentityResult::Partial { email: Some(e), .. } => Some(e.as_str()),
-            _ => None,
-        },
-        &email,
-        "email",
-    )
-}
-
-#[then("configured name is absent")]
-fn configured_name_is_absent(git_identity_state: &GitIdentityState) -> StepResult<()> {
-    assert_field_absent(
-        get_outcome(git_identity_state)?,
-        |r| {
-            matches!(
-                r,
-                GitIdentityResult::Configured { .. }
-                    | GitIdentityResult::Partial { name: Some(_), .. }
+    git_identity_state
+        .outcome
+        .with_ref(|outcome| {
+            let converted = match outcome {
+                Ok(r) => Ok(r.clone()),
+                Err(e) => Err(format!("{e}")),
+            };
+            assert_ok_variant(
+                &converted,
+                |r| matches!(r, GitIdentityResult::NoneConfigured { .. }),
+                "NoneConfigured",
             )
-        },
-        "name",
-    )
+        })
+        .ok_or_else(|| String::from("outcome not set"))?
 }
 
-#[then("configured email is absent")]
-fn configured_email_is_absent(git_identity_state: &GitIdentityState) -> StepResult<()> {
-    assert_field_absent(
-        get_outcome(git_identity_state)?,
-        |r| {
-            matches!(
-                r,
-                GitIdentityResult::Configured { .. }
-                    | GitIdentityResult::Partial { email: Some(_), .. }
-            )
-        },
-        "email",
-    )
+/// Checks configured name matches expected value.
+/// "absent" is treated specially to check for None.
+#[then("configured name is {word}")]
+fn configured_name_is(git_identity_state: &GitIdentityState, word: String) -> StepResult<()> {
+    git_identity_state
+        .outcome
+        .with_ref(|outcome| {
+            let converted = match outcome {
+                Ok(r) => Ok(r.clone()),
+                Err(e) => Err(format!("{e}")),
+            };
+
+            if word == "absent" {
+                assert_field_absent(
+                    &converted,
+                    |r| {
+                        matches!(
+                            r,
+                            GitIdentityResult::Configured { .. }
+                                | GitIdentityResult::Partial { name: Some(_), .. }
+                        )
+                    },
+                    "name",
+                )
+            } else {
+                assert_field_value(
+                    &converted,
+                    |r| match r {
+                        GitIdentityResult::Configured { name, .. } => Some(name.as_str()),
+                        GitIdentityResult::Partial { name: Some(n), .. } => Some(n.as_str()),
+                        _ => None,
+                    },
+                    &word,
+                    "name",
+                )
+            }
+        })
+        .ok_or_else(|| String::from("outcome not set"))?
 }
 
-#[then("warnings include {warning}")]
+/// Checks configured email matches expected value.
+/// "absent" is treated specially to check for None.
+#[then("configured email is {word}")]
+fn configured_email_is(git_identity_state: &GitIdentityState, word: String) -> StepResult<()> {
+    git_identity_state
+        .outcome
+        .with_ref(|outcome| {
+            let converted = match outcome {
+                Ok(r) => Ok(r.clone()),
+                Err(e) => Err(format!("{e}")),
+            };
+
+            if word == "absent" {
+                assert_field_absent(
+                    &converted,
+                    |r| {
+                        matches!(
+                            r,
+                            GitIdentityResult::Configured { .. }
+                                | GitIdentityResult::Partial { email: Some(_), .. }
+                        )
+                    },
+                    "email",
+                )
+            } else {
+                assert_field_value(
+                    &converted,
+                    |r| match r {
+                        GitIdentityResult::Configured { email, .. } => Some(email.as_str()),
+                        GitIdentityResult::Partial { email: Some(e), .. } => Some(e.as_str()),
+                        _ => None,
+                    },
+                    &word,
+                    "email",
+                )
+            }
+        })
+        .ok_or_else(|| String::from("outcome not set"))?
+}
+
+#[then("warnings include {word}")]
 fn warnings_include_warning(
     git_identity_state: &GitIdentityState,
-    warning: String,
+    word: String,
 ) -> StepResult<()> {
-    let warnings = match get_outcome(git_identity_state)? {
-        Ok(GitIdentityResult::Partial { warnings, .. }) => warnings,
-        Ok(GitIdentityResult::NoneConfigured { warnings }) => warnings,
-        Ok(other) => return Err(format!("Expected result with warnings, got {other:?}")),
-        Err(e) => return Err(format!("Expected success, got error: {e}")),
-    };
+    git_identity_state
+        .outcome
+        .with_ref(|outcome| {
+            let converted = match outcome {
+                Ok(r) => Ok(r.clone()),
+                Err(e) => Err(format!("{e}")),
+            };
+            let warnings = match &converted {
+                Ok(
+                    GitIdentityResult::Partial { warnings, .. }
+                    | GitIdentityResult::NoneConfigured { warnings },
+                ) => warnings,
+                Ok(other) => return Err(format!("Expected result with warnings, got {other:?}")),
+                Err(e) => return Err(format!("Expected success, got error: {e}")),
+            };
 
-    if warnings.contains(&warning) {
-        Ok(())
-    } else {
-        Err(format!(
-            "Expected warning '{warning}' not found in {warnings:?}"
-        ))
-    }
+            if warnings.contains(&word) {
+                Ok(())
+            } else {
+                Err(format!(
+                    "Expected warning '{word}' not found in {warnings:?}"
+                ))
+            }
+        })
+        .ok_or_else(|| String::from("outcome not set"))?
 }
 
 #[then("git identity configuration fails with an exec error")]
 fn git_identity_configuration_fails_with_exec_error(
     git_identity_state: &GitIdentityState,
 ) -> StepResult<()> {
-    match get_outcome(git_identity_state)? {
-        Err(_) => Ok(()),
-        Ok(result) => Err(format!("Expected error, got success: {result:?}")),
-    }
+    git_identity_state
+        .outcome
+        .with_ref(|outcome| {
+            outcome
+                .as_ref()
+                .map_or(Ok(()), |result| {
+                    Err(format!("Expected error, got success: {result:?}"))
+                })
+        })
+        .ok_or_else(|| String::from("outcome not set"))?
 }

--- a/tests/bdd_git_identity_helpers/assertions.rs
+++ b/tests/bdd_git_identity_helpers/assertions.rs
@@ -1,9 +1,22 @@
 //! Then step definitions for Git identity behavioural scenarios.
 
 use podbot::engine::GitIdentityResult;
+use podbot::error::{ContainerError, PodbotError};
 use rstest_bdd_macros::then;
 
 use super::state::{GitIdentityState, StepResult};
+
+/// Helper to convert the outcome from state into a cloneable Result.
+/// Since `Slot::with_ref` gives us a reference, we need to clone the
+/// `GitIdentityResult` and convert the error to String for assertions.
+fn convert_outcome(
+    outcome: &Result<GitIdentityResult, PodbotError>,
+) -> Result<GitIdentityResult, String> {
+    match outcome {
+        Ok(r) => Ok(r.clone()),
+        Err(e) => Err(format!("{e}")),
+    }
+}
 
 fn assert_ok_variant(
     outcome: &Result<GitIdentityResult, String>,
@@ -52,12 +65,8 @@ fn git_identity_result_is_configured(git_identity_state: &GitIdentityState) -> S
     git_identity_state
         .outcome
         .with_ref(|outcome| {
-            let converted = match outcome {
-                Ok(r) => Ok(r.clone()),
-                Err(e) => Err(format!("{e}")),
-            };
             assert_ok_variant(
-                &converted,
+                &convert_outcome(outcome),
                 |r| matches!(r, GitIdentityResult::Configured { .. }),
                 "Configured",
             )
@@ -70,12 +79,8 @@ fn git_identity_result_is_partial(git_identity_state: &GitIdentityState) -> Step
     git_identity_state
         .outcome
         .with_ref(|outcome| {
-            let converted = match outcome {
-                Ok(r) => Ok(r.clone()),
-                Err(e) => Err(format!("{e}")),
-            };
             assert_ok_variant(
-                &converted,
+                &convert_outcome(outcome),
                 |r| matches!(r, GitIdentityResult::Partial { .. }),
                 "Partial",
             )
@@ -88,12 +93,8 @@ fn git_identity_result_is_none_configured(git_identity_state: &GitIdentityState)
     git_identity_state
         .outcome
         .with_ref(|outcome| {
-            let converted = match outcome {
-                Ok(r) => Ok(r.clone()),
-                Err(e) => Err(format!("{e}")),
-            };
             assert_ok_variant(
-                &converted,
+                &convert_outcome(outcome),
                 |r| matches!(r, GitIdentityResult::NoneConfigured { .. }),
                 "NoneConfigured",
             )
@@ -108,10 +109,7 @@ fn configured_name_is(git_identity_state: &GitIdentityState, word: String) -> St
     git_identity_state
         .outcome
         .with_ref(|outcome| {
-            let converted = match outcome {
-                Ok(r) => Ok(r.clone()),
-                Err(e) => Err(format!("{e}")),
-            };
+            let converted = convert_outcome(outcome);
 
             if word == "absent" {
                 assert_field_absent(
@@ -148,10 +146,7 @@ fn configured_email_is(git_identity_state: &GitIdentityState, word: String) -> S
     git_identity_state
         .outcome
         .with_ref(|outcome| {
-            let converted = match outcome {
-                Ok(r) => Ok(r.clone()),
-                Err(e) => Err(format!("{e}")),
-            };
+            let converted = convert_outcome(outcome);
 
             if word == "absent" {
                 assert_field_absent(
@@ -181,15 +176,17 @@ fn configured_email_is(git_identity_state: &GitIdentityState, word: String) -> S
         .ok_or_else(|| String::from("outcome not set"))?
 }
 
-#[then("warnings include {word}")]
-fn warnings_include_warning(git_identity_state: &GitIdentityState, word: String) -> StepResult<()> {
+#[then("warnings include {string}")]
+fn warnings_include_warning(
+    git_identity_state: &GitIdentityState,
+    string: String,
+) -> StepResult<()> {
+    // rstest-bdd {string} captures include the surrounding quotes, so strip them
+    let warning = string.trim_matches('"').to_owned();
     git_identity_state
         .outcome
         .with_ref(|outcome| {
-            let converted = match outcome {
-                Ok(r) => Ok(r.clone()),
-                Err(e) => Err(format!("{e}")),
-            };
+            let converted = convert_outcome(outcome);
             let warnings = match &converted {
                 Ok(
                     GitIdentityResult::Partial { warnings, .. }
@@ -199,11 +196,11 @@ fn warnings_include_warning(git_identity_state: &GitIdentityState, word: String)
                 Err(e) => return Err(format!("Expected success, got error: {e}")),
             };
 
-            if warnings.contains(&word) {
+            if warnings.contains(&warning) {
                 Ok(())
             } else {
                 Err(format!(
-                    "Expected warning '{word}' not found in {warnings:?}"
+                    "Expected warning '{warning}' not found in {warnings:?}"
                 ))
             }
         })
@@ -216,10 +213,14 @@ fn git_identity_configuration_fails_with_exec_error(
 ) -> StepResult<()> {
     git_identity_state
         .outcome
-        .with_ref(|outcome| {
-            outcome.as_ref().map_or(Ok(()), |result| {
-                Err(format!("Expected error, got success: {result:?}"))
-            })
+        .with_ref(|outcome| match outcome {
+            Ok(result) => Err(format!(
+                "Expected exec failure error, got success: {result:?}"
+            )),
+            Err(err) => match err {
+                PodbotError::Container(ContainerError::ExecFailed { .. }) => Ok(()),
+                _ => Err(format!("Expected ContainerError::ExecFailed, got: {err:?}")),
+            },
         })
         .ok_or_else(|| String::from("outcome not set"))?
 }

--- a/tests/bdd_git_identity_helpers/assertions.rs
+++ b/tests/bdd_git_identity_helpers/assertions.rs
@@ -103,7 +103,6 @@ fn git_identity_result_is_none_configured(git_identity_state: &GitIdentityState)
 }
 
 /// Checks configured name matches expected value.
-/// "absent" is treated specially to check for None.
 #[then("configured name is {string}")]
 fn configured_name_is(git_identity_state: &GitIdentityState, string: String) -> StepResult<()> {
     // rstest-bdd {string} captures include the surrounding quotes, so strip them
@@ -113,37 +112,43 @@ fn configured_name_is(git_identity_state: &GitIdentityState, string: String) -> 
         .outcome
         .with_ref(|outcome| {
             let converted = convert_outcome(outcome);
+            assert_field_value(
+                &converted,
+                |r| match r {
+                    GitIdentityResult::Configured { name, .. } => Some(name.as_str()),
+                    GitIdentityResult::Partial { name: Some(n), .. } => Some(n.as_str()),
+                    _ => None,
+                },
+                value,
+                "name",
+            )
+        })
+        .ok_or_else(|| String::from("outcome not set"))?
+}
 
-            if value == "absent" {
-                assert_field_absent(
-                    &converted,
-                    |r| {
-                        matches!(
-                            r,
-                            GitIdentityResult::Configured { .. }
-                                | GitIdentityResult::Partial { name: Some(_), .. }
-                        )
-                    },
-                    "name",
-                )
-            } else {
-                assert_field_value(
-                    &converted,
-                    |r| match r {
-                        GitIdentityResult::Configured { name, .. } => Some(name.as_str()),
-                        GitIdentityResult::Partial { name: Some(n), .. } => Some(n.as_str()),
-                        _ => None,
-                    },
-                    value,
-                    "name",
-                )
-            }
+/// Checks that configured name is absent.
+#[then("name was not configured")]
+fn configured_name_is_absent(git_identity_state: &GitIdentityState) -> StepResult<()> {
+    git_identity_state
+        .outcome
+        .with_ref(|outcome| {
+            let converted = convert_outcome(outcome);
+            assert_field_absent(
+                &converted,
+                |r| {
+                    matches!(
+                        r,
+                        GitIdentityResult::Configured { .. }
+                            | GitIdentityResult::Partial { name: Some(_), .. }
+                    )
+                },
+                "name",
+            )
         })
         .ok_or_else(|| String::from("outcome not set"))?
 }
 
 /// Checks configured email matches expected value.
-/// "absent" is treated specially to check for None.
 #[then("configured email is {string}")]
 fn configured_email_is(git_identity_state: &GitIdentityState, string: String) -> StepResult<()> {
     // rstest-bdd {string} captures include the surrounding quotes, so strip them
@@ -153,31 +158,38 @@ fn configured_email_is(git_identity_state: &GitIdentityState, string: String) ->
         .outcome
         .with_ref(|outcome| {
             let converted = convert_outcome(outcome);
+            assert_field_value(
+                &converted,
+                |r| match r {
+                    GitIdentityResult::Configured { email, .. } => Some(email.as_str()),
+                    GitIdentityResult::Partial { email: Some(e), .. } => Some(e.as_str()),
+                    _ => None,
+                },
+                value,
+                "email",
+            )
+        })
+        .ok_or_else(|| String::from("outcome not set"))?
+}
 
-            if value == "absent" {
-                assert_field_absent(
-                    &converted,
-                    |r| {
-                        matches!(
-                            r,
-                            GitIdentityResult::Configured { .. }
-                                | GitIdentityResult::Partial { email: Some(_), .. }
-                        )
-                    },
-                    "email",
-                )
-            } else {
-                assert_field_value(
-                    &converted,
-                    |r| match r {
-                        GitIdentityResult::Configured { email, .. } => Some(email.as_str()),
-                        GitIdentityResult::Partial { email: Some(e), .. } => Some(e.as_str()),
-                        _ => None,
-                    },
-                    value,
-                    "email",
-                )
-            }
+/// Checks that configured email is absent.
+#[then("email was not configured")]
+fn configured_email_is_absent(git_identity_state: &GitIdentityState) -> StepResult<()> {
+    git_identity_state
+        .outcome
+        .with_ref(|outcome| {
+            let converted = convert_outcome(outcome);
+            assert_field_absent(
+                &converted,
+                |r| {
+                    matches!(
+                        r,
+                        GitIdentityResult::Configured { .. }
+                            | GitIdentityResult::Partial { email: Some(_), .. }
+                    )
+                },
+                "email",
+            )
         })
         .ok_or_else(|| String::from("outcome not set"))?
 }

--- a/tests/bdd_git_identity_helpers/assertions.rs
+++ b/tests/bdd_git_identity_helpers/assertions.rs
@@ -182,10 +182,7 @@ fn configured_email_is(git_identity_state: &GitIdentityState, word: String) -> S
 }
 
 #[then("warnings include {word}")]
-fn warnings_include_warning(
-    git_identity_state: &GitIdentityState,
-    word: String,
-) -> StepResult<()> {
+fn warnings_include_warning(git_identity_state: &GitIdentityState, word: String) -> StepResult<()> {
     git_identity_state
         .outcome
         .with_ref(|outcome| {
@@ -220,11 +217,9 @@ fn git_identity_configuration_fails_with_exec_error(
     git_identity_state
         .outcome
         .with_ref(|outcome| {
-            outcome
-                .as_ref()
-                .map_or(Ok(()), |result| {
-                    Err(format!("Expected error, got success: {result:?}"))
-                })
+            outcome.as_ref().map_or(Ok(()), |result| {
+                Err(format!("Expected error, got success: {result:?}"))
+            })
         })
         .ok_or_else(|| String::from("outcome not set"))?
 }

--- a/tests/bdd_git_identity_helpers/mod.rs
+++ b/tests/bdd_git_identity_helpers/mod.rs
@@ -1,0 +1,12 @@
+//! Test helpers for Git identity BDD scenarios.
+
+pub mod assertions;
+pub mod state;
+pub mod steps;
+
+pub use state::{GitIdentityState, StepResult, git_identity_state};
+
+#[expect(unused_imports, reason = "step definitions used via rstest-bdd macro expansion")]
+pub use assertions::*;
+#[expect(unused_imports, reason = "step definitions used via rstest-bdd macro expansion")]
+pub use steps::*;

--- a/tests/bdd_git_identity_helpers/mod.rs
+++ b/tests/bdd_git_identity_helpers/mod.rs
@@ -4,7 +4,7 @@ pub mod assertions;
 pub mod state;
 pub mod steps;
 
-pub use state::{GitIdentityState, StepResult, git_identity_state};
+pub use state::{GitIdentityState, git_identity_state};
 
 #[expect(
     unused_imports,

--- a/tests/bdd_git_identity_helpers/mod.rs
+++ b/tests/bdd_git_identity_helpers/mod.rs
@@ -6,7 +6,13 @@ pub mod steps;
 
 pub use state::{GitIdentityState, StepResult, git_identity_state};
 
-#[expect(unused_imports, reason = "step definitions used via rstest-bdd macro expansion")]
+#[expect(
+    unused_imports,
+    reason = "step definitions used via rstest-bdd macro expansion"
+)]
 pub use assertions::*;
-#[expect(unused_imports, reason = "step definitions used via rstest-bdd macro expansion")]
+#[expect(
+    unused_imports,
+    reason = "step definitions used via rstest-bdd macro expansion"
+)]
 pub use steps::*;

--- a/tests/bdd_git_identity_helpers/mod.rs
+++ b/tests/bdd_git_identity_helpers/mod.rs
@@ -3,6 +3,7 @@
 pub mod assertions;
 pub mod state;
 pub mod steps;
+pub mod test_helpers;
 
 pub use state::{GitIdentityState, git_identity_state};
 

--- a/tests/bdd_git_identity_helpers/state.rs
+++ b/tests/bdd_git_identity_helpers/state.rs
@@ -1,6 +1,5 @@
 //! Shared behavioural-test state for Git identity scenarios.
 
-use podbot::api::GitIdentityParams;
 use podbot::engine::GitIdentityResult;
 use podbot::error::PodbotError;
 use rstest::fixture;

--- a/tests/bdd_git_identity_helpers/state.rs
+++ b/tests/bdd_git_identity_helpers/state.rs
@@ -1,0 +1,41 @@
+//! Shared behavioural-test state for Git identity scenarios.
+
+use podbot::api::GitIdentityParams;
+use podbot::engine::GitIdentityResult;
+use podbot::error::PodbotError;
+use rstest::fixture;
+use rstest_bdd::Slot;
+use rstest_bdd_macros::ScenarioState;
+
+/// Step result type for Git identity BDD tests.
+pub type StepResult<T> = Result<T, String>;
+
+/// Shared scenario state for Git identity behavioural tests.
+#[derive(Default, ScenarioState)]
+pub struct GitIdentityState {
+    /// Host Git user.name value, if configured.
+    pub(crate) host_name: Slot<Option<String>>,
+
+    /// Host Git user.email value, if configured.
+    pub(crate) host_email: Slot<Option<String>>,
+
+    /// Target container ID for configuration.
+    pub(crate) container_id: Slot<String>,
+
+    /// Whether the container engine should fail exec calls.
+    pub(crate) should_fail_exec: Slot<bool>,
+
+    /// Outcome of the most recent configuration attempt.
+    pub(crate) outcome: Slot<Result<GitIdentityResult, PodbotError>>,
+}
+
+/// Fixture providing fresh state for each Git identity scenario.
+#[fixture]
+pub fn git_identity_state() -> GitIdentityState {
+    let state = GitIdentityState::default();
+    state.host_name.set(None);
+    state.host_email.set(None);
+    state.container_id.set(String::from("sandbox-default"));
+    state.should_fail_exec.set(false);
+    state
+}

--- a/tests/bdd_git_identity_helpers/state.rs
+++ b/tests/bdd_git_identity_helpers/state.rs
@@ -32,8 +32,6 @@ pub struct GitIdentityState {
 #[fixture]
 pub fn git_identity_state() -> GitIdentityState {
     let state = GitIdentityState::default();
-    state.host_name.set(None);
-    state.host_email.set(None);
     state.container_id.set(String::from("sandbox-default"));
     state.should_fail_exec.set(false);
     state

--- a/tests/bdd_git_identity_helpers/steps.rs
+++ b/tests/bdd_git_identity_helpers/steps.rs
@@ -55,6 +55,71 @@ fn failure_output() -> Output {
     }
 }
 
+fn setup_mock_host_runner(
+    host_name: &Option<String>,
+    host_email: &Option<String>,
+) -> MockHostRunner {
+    let mut host_runner = MockHostRunner::new();
+
+    match host_name {
+        Some(name) => {
+            let name_clone = name.clone();
+            host_runner
+                .expect_run_command()
+                .withf(|_, args| args.contains(&"user.name"))
+                .returning(move |_, _| Ok(success_output(&format!("{name_clone}\n"))));
+        }
+        None => {
+            host_runner
+                .expect_run_command()
+                .withf(|_, args| args.contains(&"user.name"))
+                .returning(|_, _| Ok(failure_output()));
+        }
+    }
+
+    match host_email {
+        Some(email) => {
+            let email_clone = email.clone();
+            host_runner
+                .expect_run_command()
+                .withf(|_, args| args.contains(&"user.email"))
+                .returning(move |_, _| Ok(success_output(&format!("{email_clone}\n"))));
+        }
+        None => {
+            host_runner
+                .expect_run_command()
+                .withf(|_, args| args.contains(&"user.email"))
+                .returning(|_, _| Ok(failure_output()));
+        }
+    }
+
+    host_runner
+}
+
+fn setup_mock_exec_client(should_fail: bool) -> MockExecClient {
+    let mut exec_client = MockExecClient::new();
+
+    exec_client
+        .expect_create_exec()
+        .returning(|_, _, _| Box::pin(async { Ok(String::from("exec-1")) }));
+    exec_client
+        .expect_start_exec()
+        .returning(|_, _| Box::pin(async { Ok(()) }));
+
+    let exit_code = if should_fail { 1 } else { 0 };
+    exec_client.expect_inspect_exec().returning(move |_| {
+        Box::pin(async move {
+            Ok(bollard::models::ExecInspectResponse {
+                exit_code: Some(exit_code),
+                running: Some(false),
+                ..Default::default()
+            })
+        })
+    });
+
+    exec_client
+}
+
 #[given("host git user.name is {name}")]
 fn host_git_name_is_name(git_identity_state: &GitIdentityState, name: String) {
     git_identity_state.host_name.set(Some(name));
@@ -107,75 +172,12 @@ fn git_identity_configuration_is_requested(
         .get()
         .ok_or_else(|| String::from("should_fail_exec not set"))?;
 
-    // Setup mock host runner
-    let mut host_runner = MockHostRunner::new();
-
-    if let Some(name) = &host_name {
-        let name_clone = name.clone();
-        host_runner
-            .expect_run_command()
-            .withf(|_, args| args.contains(&"user.name"))
-            .returning(move |_, _| Ok(success_output(&format!("{name_clone}\n"))));
-    } else {
-        host_runner
-            .expect_run_command()
-            .withf(|_, args| args.contains(&"user.name"))
-            .returning(|_, _| Ok(failure_output()));
-    }
-
-    if let Some(email) = &host_email {
-        let email_clone = email.clone();
-        host_runner
-            .expect_run_command()
-            .withf(|_, args| args.contains(&"user.email"))
-            .returning(move |_, _| Ok(success_output(&format!("{email_clone}\n"))));
-    } else {
-        host_runner
-            .expect_run_command()
-            .withf(|_, args| args.contains(&"user.email"))
-            .returning(|_, _| Ok(failure_output()));
-    }
-
-    // Setup mock exec client
-    let mut exec_client = MockExecClient::new();
-
-    if should_fail {
-        exec_client
-            .expect_create_exec()
-            .returning(|_, _, _| Box::pin(async { Ok(String::from("exec-1")) }));
-        exec_client
-            .expect_start_exec()
-            .returning(|_, _| Box::pin(async { Ok(()) }));
-        exec_client.expect_inspect_exec().returning(|_| {
-            Box::pin(async {
-                Ok(bollard::models::ExecInspectResponse {
-                    exit_code: Some(1),
-                    running: Some(false),
-                    ..Default::default()
-                })
-            })
-        });
-    } else {
-        exec_client
-            .expect_create_exec()
-            .returning(|_, _, _| Box::pin(async { Ok(String::from("exec-1")) }));
-        exec_client
-            .expect_start_exec()
-            .returning(|_, _| Box::pin(async { Ok(()) }));
-        exec_client.expect_inspect_exec().returning(|_| {
-            Box::pin(async {
-                Ok(bollard::models::ExecInspectResponse {
-                    exit_code: Some(0),
-                    running: Some(false),
-                    ..Default::default()
-                })
-            })
-        });
-    }
+    let host_runner = setup_mock_host_runner(&host_name, &host_email);
+    let exec_client = setup_mock_exec_client(should_fail);
 
     // Create runtime and execute
-    let runtime = tokio::runtime::Runtime::new()
-        .map_err(|e| format!("Failed to create runtime: {e}"))?;
+    let runtime =
+        tokio::runtime::Runtime::new().map_err(|e| format!("Failed to create runtime: {e}"))?;
     let handle = runtime.handle().clone();
 
     let params = GitIdentityParams {

--- a/tests/bdd_git_identity_helpers/steps.rs
+++ b/tests/bdd_git_identity_helpers/steps.rs
@@ -1,7 +1,6 @@
 //! Given/when step definitions for Git identity behavioural scenarios.
 
 use std::io;
-use std::os::unix::process::ExitStatusExt;
 use std::process::{ExitStatus, Output};
 
 use bollard::exec::{CreateExecOptions, ResizeExecOptions, StartExecOptions};
@@ -39,9 +38,22 @@ mock! {
     }
 }
 
+/// Create an exit status with the given exit code in a platform-independent way.
+#[cfg(unix)]
+fn exit_status(code: i32) -> ExitStatus {
+    use std::os::unix::process::ExitStatusExt;
+    ExitStatus::from_raw(code << 8)
+}
+
+#[cfg(windows)]
+fn exit_status(code: i32) -> ExitStatus {
+    use std::os::windows::process::ExitStatusExt;
+    ExitStatus::from_raw(code as u32)
+}
+
 fn success_output(stdout: &str) -> Output {
     Output {
-        status: ExitStatus::from_raw(0),
+        status: exit_status(0),
         stdout: stdout.as_bytes().to_vec(),
         stderr: Vec::new(),
     }
@@ -49,7 +61,7 @@ fn success_output(stdout: &str) -> Output {
 
 fn failure_output() -> Output {
     Output {
-        status: ExitStatus::from_raw(256),
+        status: exit_status(1),
         stdout: Vec::new(),
         stderr: b"error".to_vec(),
     }
@@ -99,13 +111,33 @@ fn setup_mock_host_runner(
 fn setup_mock_exec_client(should_fail: bool) -> MockExecClient {
     let mut exec_client = MockExecClient::new();
 
-    exec_client.expect_create_exec().returning(|_, _| {
-        Box::pin(async {
-            Ok(bollard::exec::CreateExecResults {
-                id: String::from("exec-1"),
-            })
+    exec_client
+        .expect_create_exec()
+        .withf(|_, options| {
+            // Validate that the container exec is invoking:
+            //   git config --global user.name ...
+            // or:
+            //   git config --global user.email ...
+            let Some(cmd) = &options.cmd else {
+                return false;
+            };
+
+            // We expect at least: ["git", "config", "--global", "user.name" or "user.email", ...]
+            cmd.len() >= 4
+                && cmd.first().is_some_and(|s| s == "git")
+                && cmd.get(1).is_some_and(|s| s == "config")
+                && cmd.get(2).is_some_and(|s| s == "--global")
+                && cmd
+                    .get(3)
+                    .is_some_and(|s| s == "user.name" || s == "user.email")
         })
-    });
+        .returning(|_, _| {
+            Box::pin(async {
+                Ok(bollard::exec::CreateExecResults {
+                    id: String::from("exec-1"),
+                })
+            })
+        });
     exec_client
         .expect_start_exec()
         .returning(|_, _| Box::pin(async { Ok(bollard::exec::StartExecResults::Detached) }));
@@ -177,6 +209,8 @@ fn git_identity_configuration_is_requested(
         .get()
         .ok_or_else(|| String::from("should_fail_exec not set"))?;
 
+    // Convert Option<String> to Option<&String>
+    // host_name is already Option<String> after get(), not Option<Option<String>>
     let host_runner = setup_mock_host_runner(host_name.as_ref(), host_email.as_ref());
     let exec_client = setup_mock_exec_client(should_fail);
 

--- a/tests/bdd_git_identity_helpers/steps.rs
+++ b/tests/bdd_git_identity_helpers/steps.rs
@@ -147,7 +147,8 @@ fn host_git_email_is(git_identity_state: &GitIdentityState, word: String) {
 }
 
 #[given("the container engine is available")]
-fn container_engine_is_available(_git_identity_state: &GitIdentityState) {
+fn container_engine_is_available(git_identity_state: &GitIdentityState) {
+    let _ = git_identity_state;
     // No-op: this is just narrative confirmation that exec will succeed.
 }
 

--- a/tests/bdd_git_identity_helpers/steps.rs
+++ b/tests/bdd_git_identity_helpers/steps.rs
@@ -1,7 +1,7 @@
 //! Given/when step definitions for Git identity behavioural scenarios.
 
 use std::io;
-use std::process::{ExitStatus, Output};
+use std::process::Output;
 
 use bollard::exec::{CreateExecOptions, ResizeExecOptions, StartExecOptions};
 use mockall::mock;
@@ -13,6 +13,7 @@ use podbot::engine::{
 use rstest_bdd_macros::{given, when};
 
 use super::state::{GitIdentityState, StepResult};
+use super::test_helpers::{failure_output, success_output};
 
 mock! {
     #[derive(Debug)]
@@ -35,35 +36,6 @@ mock! {
         fn start_exec(&self, exec_id: &str, options: Option<StartExecOptions>) -> StartExecFuture<'_>;
         fn inspect_exec(&self, exec_id: &str) -> InspectExecFuture<'_>;
         fn resize_exec(&self, exec_id: &str, options: ResizeExecOptions) -> ResizeExecFuture<'_>;
-    }
-}
-
-/// Create an exit status with the given exit code in a platform-independent way.
-#[cfg(unix)]
-fn exit_status(code: i32) -> ExitStatus {
-    use std::os::unix::process::ExitStatusExt;
-    ExitStatus::from_raw(code << 8)
-}
-
-#[cfg(windows)]
-fn exit_status(code: i32) -> ExitStatus {
-    use std::os::windows::process::ExitStatusExt;
-    ExitStatus::from_raw(code as u32)
-}
-
-fn success_output(stdout: &str) -> Output {
-    Output {
-        status: exit_status(0),
-        stdout: stdout.as_bytes().to_vec(),
-        stderr: Vec::new(),
-    }
-}
-
-fn failure_output() -> Output {
-    Output {
-        status: exit_status(1),
-        stdout: Vec::new(),
-        stderr: b"error".to_vec(),
     }
 }
 

--- a/tests/bdd_git_identity_helpers/steps.rs
+++ b/tests/bdd_git_identity_helpers/steps.rs
@@ -8,8 +8,8 @@ use bollard::exec::{CreateExecOptions, ResizeExecOptions, StartExecOptions};
 use mockall::mock;
 use podbot::api::{GitIdentityParams, configure_container_git_identity};
 use podbot::engine::{
-    ContainerExecClient, CreateExecFuture, HostCommandRunner, InspectExecFuture,
-    ResizeExecFuture, StartExecFuture,
+    ContainerExecClient, CreateExecFuture, HostCommandRunner, InspectExecFuture, ResizeExecFuture,
+    StartExecFuture,
 };
 use rstest_bdd_macros::{given, when};
 
@@ -106,9 +106,9 @@ fn setup_mock_exec_client(should_fail: bool) -> MockExecClient {
             })
         })
     });
-    exec_client.expect_start_exec().returning(|_, _| {
-        Box::pin(async { Ok(bollard::exec::StartExecResults::Detached) })
-    });
+    exec_client
+        .expect_start_exec()
+        .returning(|_, _| Box::pin(async { Ok(bollard::exec::StartExecResults::Detached) }));
 
     let exit_code = i64::from(should_fail);
     exec_client.expect_inspect_exec().returning(move |_| {

--- a/tests/bdd_git_identity_helpers/steps.rs
+++ b/tests/bdd_git_identity_helpers/steps.rs
@@ -158,8 +158,10 @@ fn setup_mock_exec_client(should_fail: bool) -> MockExecClient {
 
 /// Sets host git user.name from feature file.
 /// "missing" is treated specially to indicate None.
-#[given("host git user.name is {word}")]
-fn host_git_name_is(git_identity_state: &GitIdentityState, word: String) {
+#[given("host git user.name is {string}")]
+fn host_git_name_is(git_identity_state: &GitIdentityState, string: String) {
+    // rstest-bdd {string} captures include the surrounding quotes, so strip them
+    let word = string.trim_matches('"').to_owned();
     if word == "missing" {
         git_identity_state.host_name.set(None);
     } else {
@@ -169,8 +171,10 @@ fn host_git_name_is(git_identity_state: &GitIdentityState, word: String) {
 
 /// Sets host git user.email from feature file.
 /// "missing" is treated specially to indicate None.
-#[given("host git user.email is {word}")]
-fn host_git_email_is(git_identity_state: &GitIdentityState, word: String) {
+#[given("host git user.email is {string}")]
+fn host_git_email_is(git_identity_state: &GitIdentityState, string: String) {
+    // rstest-bdd {string} captures include the surrounding quotes, so strip them
+    let word = string.trim_matches('"').to_owned();
     if word == "missing" {
         git_identity_state.host_email.set(None);
     } else {

--- a/tests/bdd_git_identity_helpers/steps.rs
+++ b/tests/bdd_git_identity_helpers/steps.rs
@@ -1,0 +1,192 @@
+//! Given/when step definitions for Git identity behavioural scenarios.
+
+use std::io;
+use std::os::unix::process::ExitStatusExt;
+use std::process::{ExitStatus, Output};
+
+use mockall::mock;
+use podbot::api::{GitIdentityParams, configure_container_git_identity};
+use podbot::engine::{
+    ContainerExecClient, CreateExecFuture, EngineConnector, ExecMode, ExecRequest, ExecResult,
+    HostCommandRunner, InspectExecFuture, ResizeExecFuture, StartExecFuture,
+};
+use podbot::error::{ContainerError, PodbotError};
+use rstest_bdd_macros::{given, when};
+
+use super::state::{GitIdentityState, StepResult};
+
+mock! {
+    #[derive(Debug)]
+    HostRunner {}
+    impl HostCommandRunner for HostRunner {
+        fn run_command<'a>(
+            &self,
+            program: &'a str,
+            args: &'a [&'a str],
+        ) -> io::Result<Output>;
+    }
+}
+
+mock! {
+    #[derive(Debug)]
+    ExecClient {}
+    impl ContainerExecClient for ExecClient {
+        fn create_exec(&self, container_id: &str, command: Vec<String>, tty: bool)
+            -> CreateExecFuture<'_>;
+        fn start_exec(&self, exec_id: &str, tty: bool) -> StartExecFuture<'_>;
+        fn inspect_exec(&self, exec_id: &str) -> InspectExecFuture<'_>;
+        fn resize_exec(&self, exec_id: &str, width: u16, height: u16) -> ResizeExecFuture<'_>;
+    }
+}
+
+fn success_output(stdout: &str) -> Output {
+    Output {
+        status: ExitStatus::from_raw(0),
+        stdout: stdout.as_bytes().to_vec(),
+        stderr: Vec::new(),
+    }
+}
+
+fn failure_output() -> Output {
+    Output {
+        status: ExitStatus::from_raw(256),
+        stdout: Vec::new(),
+        stderr: b"error".to_vec(),
+    }
+}
+
+#[given("host git user.name is {name}")]
+fn host_git_name_is_name(git_identity_state: &GitIdentityState, name: String) {
+    git_identity_state.host_name.set(Some(name));
+}
+
+#[given("host git user.email is {email}")]
+fn host_git_email_is_email(git_identity_state: &GitIdentityState, email: String) {
+    git_identity_state.host_email.set(Some(email));
+}
+
+#[given("host git user.name is missing")]
+fn host_git_name_is_missing(git_identity_state: &GitIdentityState) {
+    git_identity_state.host_name.set(None);
+}
+
+#[given("host git user.email is missing")]
+fn host_git_email_is_missing(git_identity_state: &GitIdentityState) {
+    git_identity_state.host_email.set(None);
+}
+
+#[given("the container engine is available")]
+fn container_engine_is_available(_git_identity_state: &GitIdentityState) {
+    // No-op: this is just narrative confirmation that exec will succeed.
+}
+
+#[given("the container engine exec will fail")]
+fn container_engine_exec_will_fail(git_identity_state: &GitIdentityState) {
+    git_identity_state.should_fail_exec.set(true);
+}
+
+#[when("git identity configuration is requested for container {container_id}")]
+fn git_identity_configuration_is_requested(
+    git_identity_state: &GitIdentityState,
+    container_id: String,
+) -> StepResult<()> {
+    git_identity_state.container_id.set(container_id.clone());
+
+    let host_name = git_identity_state
+        .host_name
+        .get()
+        .ok_or_else(|| String::from("host_name not set"))?
+        .clone();
+    let host_email = git_identity_state
+        .host_email
+        .get()
+        .ok_or_else(|| String::from("host_email not set"))?
+        .clone();
+    let should_fail = git_identity_state
+        .should_fail_exec
+        .get()
+        .ok_or_else(|| String::from("should_fail_exec not set"))?;
+
+    // Setup mock host runner
+    let mut host_runner = MockHostRunner::new();
+
+    if let Some(name) = &host_name {
+        let name_clone = name.clone();
+        host_runner
+            .expect_run_command()
+            .withf(|_, args| args.contains(&"user.name"))
+            .returning(move |_, _| Ok(success_output(&format!("{name_clone}\n"))));
+    } else {
+        host_runner
+            .expect_run_command()
+            .withf(|_, args| args.contains(&"user.name"))
+            .returning(|_, _| Ok(failure_output()));
+    }
+
+    if let Some(email) = &host_email {
+        let email_clone = email.clone();
+        host_runner
+            .expect_run_command()
+            .withf(|_, args| args.contains(&"user.email"))
+            .returning(move |_, _| Ok(success_output(&format!("{email_clone}\n"))));
+    } else {
+        host_runner
+            .expect_run_command()
+            .withf(|_, args| args.contains(&"user.email"))
+            .returning(|_, _| Ok(failure_output()));
+    }
+
+    // Setup mock exec client
+    let mut exec_client = MockExecClient::new();
+
+    if should_fail {
+        exec_client
+            .expect_create_exec()
+            .returning(|_, _, _| Box::pin(async { Ok(String::from("exec-1")) }));
+        exec_client
+            .expect_start_exec()
+            .returning(|_, _| Box::pin(async { Ok(()) }));
+        exec_client.expect_inspect_exec().returning(|_| {
+            Box::pin(async {
+                Ok(bollard::models::ExecInspectResponse {
+                    exit_code: Some(1),
+                    running: Some(false),
+                    ..Default::default()
+                })
+            })
+        });
+    } else {
+        exec_client
+            .expect_create_exec()
+            .returning(|_, _, _| Box::pin(async { Ok(String::from("exec-1")) }));
+        exec_client
+            .expect_start_exec()
+            .returning(|_, _| Box::pin(async { Ok(()) }));
+        exec_client.expect_inspect_exec().returning(|_| {
+            Box::pin(async {
+                Ok(bollard::models::ExecInspectResponse {
+                    exit_code: Some(0),
+                    running: Some(false),
+                    ..Default::default()
+                })
+            })
+        });
+    }
+
+    // Create runtime and execute
+    let runtime = tokio::runtime::Runtime::new()
+        .map_err(|e| format!("Failed to create runtime: {e}"))?;
+    let handle = runtime.handle().clone();
+
+    let params = GitIdentityParams {
+        client: &exec_client,
+        host_runner: &host_runner,
+        container_id: &container_id,
+        runtime_handle: &handle,
+    };
+
+    let result = configure_container_git_identity(&params);
+    git_identity_state.outcome.set(result);
+
+    Ok(())
+}

--- a/tests/bdd_git_identity_helpers/steps.rs
+++ b/tests/bdd_git_identity_helpers/steps.rs
@@ -67,44 +67,38 @@ fn failure_output() -> Output {
     }
 }
 
+/// Register an `expect_run_command` expectation on `runner` that matches
+/// commands containing `config_key` and returns `success_output` when a
+/// value is present or `failure_output` when absent.
+fn register_user_config(
+    runner: &mut MockHostRunner,
+    config_key: &'static str,
+    value: Option<&String>,
+) {
+    match value {
+        Some(v) => {
+            let owned = v.clone();
+            runner
+                .expect_run_command()
+                .withf(move |_, args| args.contains(&config_key))
+                .returning(move |_, _| Ok(success_output(&format!("{owned}\n"))));
+        }
+        None => {
+            runner
+                .expect_run_command()
+                .withf(move |_, args| args.contains(&config_key))
+                .returning(|_, _| Ok(failure_output()));
+        }
+    }
+}
+
 fn setup_mock_host_runner(
     host_name: Option<&String>,
     host_email: Option<&String>,
 ) -> MockHostRunner {
     let mut host_runner = MockHostRunner::new();
-
-    match host_name {
-        Some(name) => {
-            let name_clone = name.clone();
-            host_runner
-                .expect_run_command()
-                .withf(|_, args| args.contains(&"user.name"))
-                .returning(move |_, _| Ok(success_output(&format!("{name_clone}\n"))));
-        }
-        None => {
-            host_runner
-                .expect_run_command()
-                .withf(|_, args| args.contains(&"user.name"))
-                .returning(|_, _| Ok(failure_output()));
-        }
-    }
-
-    match host_email {
-        Some(email) => {
-            let email_clone = email.clone();
-            host_runner
-                .expect_run_command()
-                .withf(|_, args| args.contains(&"user.email"))
-                .returning(move |_, _| Ok(success_output(&format!("{email_clone}\n"))));
-        }
-        None => {
-            host_runner
-                .expect_run_command()
-                .withf(|_, args| args.contains(&"user.email"))
-                .returning(|_, _| Ok(failure_output()));
-        }
-    }
-
+    register_user_config(&mut host_runner, "user.name", host_name);
+    register_user_config(&mut host_runner, "user.email", host_email);
     host_runner
 }
 

--- a/tests/bdd_git_identity_helpers/steps.rs
+++ b/tests/bdd_git_identity_helpers/steps.rs
@@ -4,13 +4,13 @@ use std::io;
 use std::os::unix::process::ExitStatusExt;
 use std::process::{ExitStatus, Output};
 
+use bollard::exec::{CreateExecOptions, ResizeExecOptions, StartExecOptions};
 use mockall::mock;
 use podbot::api::{GitIdentityParams, configure_container_git_identity};
 use podbot::engine::{
-    ContainerExecClient, CreateExecFuture, EngineConnector, ExecMode, ExecRequest, ExecResult,
-    HostCommandRunner, InspectExecFuture, ResizeExecFuture, StartExecFuture,
+    ContainerExecClient, CreateExecFuture, HostCommandRunner, InspectExecFuture,
+    ResizeExecFuture, StartExecFuture,
 };
-use podbot::error::{ContainerError, PodbotError};
 use rstest_bdd_macros::{given, when};
 
 use super::state::{GitIdentityState, StepResult};
@@ -31,11 +31,11 @@ mock! {
     #[derive(Debug)]
     ExecClient {}
     impl ContainerExecClient for ExecClient {
-        fn create_exec(&self, container_id: &str, command: Vec<String>, tty: bool)
+        fn create_exec(&self, container_id: &str, options: CreateExecOptions<String>)
             -> CreateExecFuture<'_>;
-        fn start_exec(&self, exec_id: &str, tty: bool) -> StartExecFuture<'_>;
+        fn start_exec(&self, exec_id: &str, options: Option<StartExecOptions>) -> StartExecFuture<'_>;
         fn inspect_exec(&self, exec_id: &str) -> InspectExecFuture<'_>;
-        fn resize_exec(&self, exec_id: &str, width: u16, height: u16) -> ResizeExecFuture<'_>;
+        fn resize_exec(&self, exec_id: &str, options: ResizeExecOptions) -> ResizeExecFuture<'_>;
     }
 }
 
@@ -56,8 +56,8 @@ fn failure_output() -> Output {
 }
 
 fn setup_mock_host_runner(
-    host_name: &Option<String>,
-    host_email: &Option<String>,
+    host_name: Option<&String>,
+    host_email: Option<&String>,
 ) -> MockHostRunner {
     let mut host_runner = MockHostRunner::new();
 
@@ -99,14 +99,18 @@ fn setup_mock_host_runner(
 fn setup_mock_exec_client(should_fail: bool) -> MockExecClient {
     let mut exec_client = MockExecClient::new();
 
-    exec_client
-        .expect_create_exec()
-        .returning(|_, _, _| Box::pin(async { Ok(String::from("exec-1")) }));
-    exec_client
-        .expect_start_exec()
-        .returning(|_, _| Box::pin(async { Ok(()) }));
+    exec_client.expect_create_exec().returning(|_, _| {
+        Box::pin(async {
+            Ok(bollard::exec::CreateExecResults {
+                id: String::from("exec-1"),
+            })
+        })
+    });
+    exec_client.expect_start_exec().returning(|_, _| {
+        Box::pin(async { Ok(bollard::exec::StartExecResults::Detached) })
+    });
 
-    let exit_code = if should_fail { 1 } else { 0 };
+    let exit_code = i64::from(should_fail);
     exec_client.expect_inspect_exec().returning(move |_| {
         Box::pin(async move {
             Ok(bollard::models::ExecInspectResponse {
@@ -120,24 +124,26 @@ fn setup_mock_exec_client(should_fail: bool) -> MockExecClient {
     exec_client
 }
 
-#[given("host git user.name is {name}")]
-fn host_git_name_is_name(git_identity_state: &GitIdentityState, name: String) {
-    git_identity_state.host_name.set(Some(name));
+/// Sets host git user.name from feature file.
+/// "missing" is treated specially to indicate None.
+#[given("host git user.name is {word}")]
+fn host_git_name_is(git_identity_state: &GitIdentityState, word: String) {
+    if word == "missing" {
+        git_identity_state.host_name.set(None);
+    } else {
+        git_identity_state.host_name.set(Some(word));
+    }
 }
 
-#[given("host git user.email is {email}")]
-fn host_git_email_is_email(git_identity_state: &GitIdentityState, email: String) {
-    git_identity_state.host_email.set(Some(email));
-}
-
-#[given("host git user.name is missing")]
-fn host_git_name_is_missing(git_identity_state: &GitIdentityState) {
-    git_identity_state.host_name.set(None);
-}
-
-#[given("host git user.email is missing")]
-fn host_git_email_is_missing(git_identity_state: &GitIdentityState) {
-    git_identity_state.host_email.set(None);
+/// Sets host git user.email from feature file.
+/// "missing" is treated specially to indicate None.
+#[given("host git user.email is {word}")]
+fn host_git_email_is(git_identity_state: &GitIdentityState, word: String) {
+    if word == "missing" {
+        git_identity_state.host_email.set(None);
+    } else {
+        git_identity_state.host_email.set(Some(word));
+    }
 }
 
 #[given("the container engine is available")]
@@ -160,19 +166,17 @@ fn git_identity_configuration_is_requested(
     let host_name = git_identity_state
         .host_name
         .get()
-        .ok_or_else(|| String::from("host_name not set"))?
-        .clone();
+        .ok_or_else(|| String::from("host_name not set"))?;
     let host_email = git_identity_state
         .host_email
         .get()
-        .ok_or_else(|| String::from("host_email not set"))?
-        .clone();
+        .ok_or_else(|| String::from("host_email not set"))?;
     let should_fail = git_identity_state
         .should_fail_exec
         .get()
         .ok_or_else(|| String::from("should_fail_exec not set"))?;
 
-    let host_runner = setup_mock_host_runner(&host_name, &host_email);
+    let host_runner = setup_mock_host_runner(host_name.as_ref(), host_email.as_ref());
     let exec_client = setup_mock_exec_client(should_fail);
 
     // Create runtime and execute

--- a/tests/bdd_git_identity_helpers/test_helpers.rs
+++ b/tests/bdd_git_identity_helpers/test_helpers.rs
@@ -1,0 +1,38 @@
+//! Shared test helpers for Git identity integration tests.
+//!
+//! Provides platform-independent `ExitStatus` construction and
+//! `std::process::Output` factories used by step definitions.
+
+use std::process::{ExitStatus, Output};
+
+/// Platform-independent exit status construction.
+#[cfg(unix)]
+pub fn exit_status(code: i32) -> ExitStatus {
+    use std::os::unix::process::ExitStatusExt;
+    ExitStatus::from_raw(code << 8)
+}
+
+/// Platform-independent exit status construction.
+#[cfg(windows)]
+pub fn exit_status(code: i32) -> ExitStatus {
+    use std::os::windows::process::ExitStatusExt;
+    ExitStatus::from_raw(code as u32)
+}
+
+/// Build a successful `Output` with the given stdout content.
+pub fn success_output(stdout: &str) -> Output {
+    Output {
+        status: exit_status(0),
+        stdout: stdout.as_bytes().to_vec(),
+        stderr: Vec::new(),
+    }
+}
+
+/// Build a failed `Output` (exit code 1) with a generic stderr message.
+pub fn failure_output() -> Output {
+    Output {
+        status: exit_status(1),
+        stdout: Vec::new(),
+        stderr: b"error".to_vec(),
+    }
+}

--- a/tests/features/git_identity.feature
+++ b/tests/features/git_identity.feature
@@ -20,7 +20,7 @@ Feature: Git identity configuration
     Then git identity result is partial
     And configured name is Bob
     And configured email is absent
-    And warnings include git user.email is not configured on the host
+    And warnings include "git user.email is not configured on the host"
 
   Scenario: Only email is configured on the host
     Given host git user.name is missing
@@ -30,7 +30,7 @@ Feature: Git identity configuration
     Then git identity result is partial
     And configured name is absent
     And configured email is carol@example.com
-    And warnings include git user.name is not configured on the host
+    And warnings include "git user.name is not configured on the host"
 
   Scenario: Neither name nor email is configured
     Given host git user.name is missing
@@ -38,8 +38,8 @@ Feature: Git identity configuration
     And the container engine is available
     When git identity configuration is requested for container sandbox-4
     Then git identity result is none configured
-    And warnings include git user.name is not configured on the host
-    And warnings include git user.email is not configured on the host
+    And warnings include "git user.name is not configured on the host"
+    And warnings include "git user.email is not configured on the host"
 
   Scenario: Container exec failure propagates as error
     Given host git user.name is Alice

--- a/tests/features/git_identity.feature
+++ b/tests/features/git_identity.feature
@@ -4,8 +4,8 @@ Feature: Git identity configuration
   user.name and user.email from the host Git configuration.
 
   Scenario: Both name and email are configured
-    Given host git user.name is Alice
-    And host git user.email is alice@example.com
+    Given host git user.name is "Alice"
+    And host git user.email is "alice@example.com"
     And the container engine is available
     When git identity configuration is requested for container sandbox-1
     Then git identity result is configured
@@ -13,8 +13,8 @@ Feature: Git identity configuration
     And configured email is "alice@example.com"
 
   Scenario: Only name is configured on the host
-    Given host git user.name is Bob
-    And host git user.email is missing
+    Given host git user.name is "Bob"
+    And host git user.email is "missing"
     And the container engine is available
     When git identity configuration is requested for container sandbox-2
     Then git identity result is partial
@@ -23,8 +23,8 @@ Feature: Git identity configuration
     And warnings include "git user.email is not configured on the host"
 
   Scenario: Only email is configured on the host
-    Given host git user.name is missing
-    And host git user.email is carol@example.com
+    Given host git user.name is "missing"
+    And host git user.email is "carol@example.com"
     And the container engine is available
     When git identity configuration is requested for container sandbox-3
     Then git identity result is partial
@@ -33,8 +33,8 @@ Feature: Git identity configuration
     And warnings include "git user.name is not configured on the host"
 
   Scenario: Neither name nor email is configured
-    Given host git user.name is missing
-    And host git user.email is missing
+    Given host git user.name is "missing"
+    And host git user.email is "missing"
     And the container engine is available
     When git identity configuration is requested for container sandbox-4
     Then git identity result is none configured
@@ -42,8 +42,8 @@ Feature: Git identity configuration
     And warnings include "git user.email is not configured on the host"
 
   Scenario: Multi-word name is configured
-    Given host git user.name is Alice Smith
-    And host git user.email is alice.smith@example.com
+    Given host git user.name is "Alice Smith"
+    And host git user.email is "alice.smith@example.com"
     And the container engine is available
     When git identity configuration is requested for container sandbox-5
     Then git identity result is configured
@@ -51,8 +51,8 @@ Feature: Git identity configuration
     And configured email is "alice.smith@example.com"
 
   Scenario: Container exec failure propagates as error
-    Given host git user.name is Alice
-    And host git user.email is alice@example.com
+    Given host git user.name is "Alice"
+    And host git user.email is "alice@example.com"
     And the container engine exec will fail
     When git identity configuration is requested for container sandbox-6
     Then git identity configuration fails with an exec error

--- a/tests/features/git_identity.feature
+++ b/tests/features/git_identity.feature
@@ -9,8 +9,8 @@ Feature: Git identity configuration
     And the container engine is available
     When git identity configuration is requested for container sandbox-1
     Then git identity result is configured
-    And configured name is Alice
-    And configured email is alice@example.com
+    And configured name is "Alice"
+    And configured email is "alice@example.com"
 
   Scenario: Only name is configured on the host
     Given host git user.name is Bob
@@ -18,8 +18,8 @@ Feature: Git identity configuration
     And the container engine is available
     When git identity configuration is requested for container sandbox-2
     Then git identity result is partial
-    And configured name is Bob
-    And configured email is absent
+    And configured name is "Bob"
+    And configured email is "absent"
     And warnings include "git user.email is not configured on the host"
 
   Scenario: Only email is configured on the host
@@ -28,8 +28,8 @@ Feature: Git identity configuration
     And the container engine is available
     When git identity configuration is requested for container sandbox-3
     Then git identity result is partial
-    And configured name is absent
-    And configured email is carol@example.com
+    And configured name is "absent"
+    And configured email is "carol@example.com"
     And warnings include "git user.name is not configured on the host"
 
   Scenario: Neither name nor email is configured

--- a/tests/features/git_identity.feature
+++ b/tests/features/git_identity.feature
@@ -19,7 +19,7 @@ Feature: Git identity configuration
     When git identity configuration is requested for container sandbox-2
     Then git identity result is partial
     And configured name is "Bob"
-    And configured email is "absent"
+    And email was not configured
     And warnings include "git user.email is not configured on the host"
 
   Scenario: Only email is configured on the host
@@ -28,7 +28,7 @@ Feature: Git identity configuration
     And the container engine is available
     When git identity configuration is requested for container sandbox-3
     Then git identity result is partial
-    And configured name is "absent"
+    And name was not configured
     And configured email is "carol@example.com"
     And warnings include "git user.name is not configured on the host"
 
@@ -41,9 +41,18 @@ Feature: Git identity configuration
     And warnings include "git user.name is not configured on the host"
     And warnings include "git user.email is not configured on the host"
 
+  Scenario: Multi-word name is configured
+    Given host git user.name is Alice Smith
+    And host git user.email is alice.smith@example.com
+    And the container engine is available
+    When git identity configuration is requested for container sandbox-5
+    Then git identity result is configured
+    And configured name is "Alice Smith"
+    And configured email is "alice.smith@example.com"
+
   Scenario: Container exec failure propagates as error
     Given host git user.name is Alice
     And host git user.email is alice@example.com
     And the container engine exec will fail
-    When git identity configuration is requested for container sandbox-5
+    When git identity configuration is requested for container sandbox-6
     Then git identity configuration fails with an exec error

--- a/tests/features/git_identity.feature
+++ b/tests/features/git_identity.feature
@@ -1,0 +1,49 @@
+Feature: Git identity configuration
+
+  Configure Git identity within the container by reading
+  user.name and user.email from the host Git configuration.
+
+  Scenario: Both name and email are configured
+    Given host git user.name is Alice
+    And host git user.email is alice@example.com
+    And the container engine is available
+    When git identity configuration is requested for container sandbox-1
+    Then git identity result is configured
+    And configured name is Alice
+    And configured email is alice@example.com
+
+  Scenario: Only name is configured on the host
+    Given host git user.name is Bob
+    And host git user.email is missing
+    And the container engine is available
+    When git identity configuration is requested for container sandbox-2
+    Then git identity result is partial
+    And configured name is Bob
+    And configured email is absent
+    And warnings include git user.email is not configured on the host
+
+  Scenario: Only email is configured on the host
+    Given host git user.name is missing
+    And host git user.email is carol@example.com
+    And the container engine is available
+    When git identity configuration is requested for container sandbox-3
+    Then git identity result is partial
+    And configured name is absent
+    And configured email is carol@example.com
+    And warnings include git user.name is not configured on the host
+
+  Scenario: Neither name nor email is configured
+    Given host git user.name is missing
+    And host git user.email is missing
+    And the container engine is available
+    When git identity configuration is requested for container sandbox-4
+    Then git identity result is none configured
+    And warnings include git user.name is not configured on the host
+    And warnings include git user.email is not configured on the host
+
+  Scenario: Container exec failure propagates as error
+    Given host git user.name is Alice
+    And host git user.email is alice@example.com
+    And the container engine exec will fail
+    When git identity configuration is requested for container sandbox-5
+    Then git identity configuration fails with an exec error


### PR DESCRIPTION
## Summary
- Expands the git_identity feature to propagate host Git identity into containers via git config --global, with host-reader and container configurator in the engine, plus API orchestration, tests, and documentation scaffolding.
- Introduces engine module at src/engine/connection/git_identity with host_reader.rs, container_configurator.rs, mod.rs, and tests.rs.
- Adds API orchestration in src/api/configure_git_identity.rs that wires host identity reading to container configuration; exports in src/api/mod.rs.
- Updates public API surface to re-export new git_identity types and functions from src/engine/connection/mod.rs and src/engine/mod.rs.
- Adds behavioural (BDD) and unit-test scaffolding under tests/, including features, steps, assertions, and helper state.
- Documentation scaffolding updated with an execution plan document and references in design/users-guide/roadmap to reflect the new module and behavior.
- Validation remains additive and warning-driven when host identity is incomplete.

## Changes
- Engine: add new git_identity module under src/engine/connection/git_identity with:
  - host_reader.rs: HostCommandRunner trait, SystemCommandRunner, and HostGitIdentity struct; reads host git config values.
  - container_configurator.rs: Executes git config --global user.name and user.email inside the container; defines GitIdentityResult enum (Configured, Partial, NoneConfigured).
  - mod.rs: module hub and re-exports for public API surface.
  - tests.rs: unit tests for host reader and basic container config paths.
- API: introduce orchestration for Git identity configuration:
  - api/configure_git_identity.rs: GitIdentityParams and configure_container_git_identity tying host reader and container config together using runtime and container client.
  - api/mod.rs: export new orchestration module types.
- Public API surface: update src/engine/connection/mod.rs and src/engine/mod.rs to re-export new git_identity types and functions (HostCommandRunner, SystemCommandRunner, HostGitIdentity, GitIdentityResult, read_host_git_identity, configure_git_identity).
- API surface: update src/api/mod.rs to export GitIdentityParams and configure_container_git_identity.
- Tests: unit tests for host reader and basic integration paths; BDD tests scaffolding added (BDD helpers, features, steps, assertions) under tests/
- Documentation: add docs/execplans/4-1-1-git-identity-configuration.md; update docs/podbot-design.md note on git_identity; update docs/users-guide.md with Git identity configuration behavior; update docs/podbot-roadmap.md to reflect the new feature.
- Tests: behavioural tests scaffolding and unit tests for host reader; BDD helpers and feature files included.

## How to test
- Gate checks: make check-fmt, make lint, make test.
- Validate unit tests for host reader pass.
- Validate integration paths with the new API orchestration function using mocks for HostCommandRunner and ContainerExecClient.
- Ensure no breaking changes to existing public APIs beyond addition of new modules.

## Migration & Compatibility
- Public API is additive; no breaking changes to existing signatures.
- New types are additive; host-to-container behavior is warning-driven when host identity is incomplete.

## Risks & Mitigations
- If host git is not installed or host identity missing, it surfaces as Partial/NoneConfigured warnings rather than errors.
- Container image may lack git; container-side exec failures are surfaced as errors via ExecFailed where appropriate.
- No new external dependencies introduced.

## Validation and acceptance
- Host identity read from the host (name and/or email) with graceful fallbacks.
- Container-side configuration performed via git config --global inside the container.
- Missing host identity yields warnings rather than errors; complete identity yields Configured; partial yields Partial.
- Unit tests for host reader cover configured, missing, whitespace, and empty output scenarios; BDD scaffolding added for end-to-end flow.
- API orchestration wired and ready for Stage C/BDD tests.
- Documentation scaffolding updated to reflect new behavior (exec plan, design, users-guide, roadmap).

📎 **Task**: https://www.devboxer.com/task/941e79a2-8bb7-448b-b725-e656bc599550