### PR TITLE
Wire CodeScene coverage upload and ratchet into CI

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
       - name: Setup Rust
-        uses: leynos/shared-actions/.github/actions/setup-rust@aebb3f5b831102e2a10ef909c83d7d50ea86c332
+        uses: leynos/shared-actions/.github/actions/setup-rust@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
       - name: Install cargo-audit
         run: cargo binstall --no-confirm cargo-audit
       - name: Setup Python for audit manifest extraction

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,6 +76,7 @@ jobs:
           features: internal
           output-path: lcov.info
           format: lcov
+          use-cargo-nextest: 'false'
           with-ratchet: 'true'
       # The `mode: check` step is deliberately not wired in yet: CodeScene
       # project 75835 has no coverage-gates configuration, so

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,8 +16,10 @@ jobs:
       WHITAKER_INSTALLER_VERSION: '0.2.5'
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          fetch-depth: 0
       - name: Setup Rust
-        uses: leynos/shared-actions/.github/actions/setup-rust@aebb3f5b831102e2a10ef909c83d7d50ea86c332
+        uses: leynos/shared-actions/.github/actions/setup-rust@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
       - name: Format
         run: make check-fmt
       - name: Markdown lint
@@ -69,17 +71,22 @@ jobs:
       - name: Internal compatibility tests
         run: cargo test --features internal
       - name: Test and Measure Coverage
-        uses: leynos/shared-actions/.github/actions/generate-coverage@aebb3f5b831102e2a10ef909c83d7d50ea86c332
+        uses: leynos/shared-actions/.github/actions/generate-coverage@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
         with:
           features: internal
           output-path: lcov.info
           format: lcov
-      - name: Upload coverage data to CodeScene
-        env:
-          CS_ACCESS_TOKEN: ${{ secrets.CS_ACCESS_TOKEN }}
-        if: ${{ env.CS_ACCESS_TOKEN }}
-        uses: leynos/shared-actions/.github/actions/upload-codescene-coverage@aebb3f5b831102e2a10ef909c83d7d50ea86c332
-        with:
-          format: lcov
-          access-token: ${{ env.CS_ACCESS_TOKEN }}
-          installer-checksum: ${{ vars.CODESCENE_CLI_SHA256 }}
+          with-ratchet: 'true'
+      # The `mode: check` step is deliberately not wired in yet: CodeScene
+      # project 75835 has no coverage-gates configuration, so
+      # `cs-coverage check` is expected to fail every run with "HTTP call
+      # succeeded, but the received project-config isn't valid. Lacks the
+      # gates configuration." — a CodeScene-side per-project setting, not a
+      # CI defect (ddlint and chutoro hit the byte-identical error). Add the
+      # check step in a fast-follow PR once coverage-main.yml has uploaded
+      # to main at least once and the gate is confirmed to resolve, or once
+      # CodeScene confirms the project's coverage gate is enabled.
+      #
+      # Coverage is uploaded to CodeScene from coverage-main.yml on push to
+      # main instead of here: CodeScene's `cs-coverage upload` only accepts
+      # analysed branches, and this job runs on pull_request only.

--- a/.github/workflows/coverage-main.yml
+++ b/.github/workflows/coverage-main.yml
@@ -31,6 +31,7 @@ jobs:
           features: internal
           output-path: lcov.info
           format: lcov
+          use-cargo-nextest: 'false'
           with-ratchet: 'true'
       - name: Upload coverage data to CodeScene
         env:

--- a/.github/workflows/coverage-main.yml
+++ b/.github/workflows/coverage-main.yml
@@ -1,0 +1,43 @@
+name: Coverage (main)
+
+# CodeScene accepts `cs-coverage upload` only for analysed branches, so
+# main-branch coverage is uploaded here on push; pull requests only
+# generate coverage in ci.yml (the changed-line `cs-coverage check` gate
+# is deferred until the project's coverage-gates configuration is
+# enabled — see the comment in ci.yml). This workflow also advances the
+# coverage ratchet baseline: caches saved on main are readable by every
+# pull-request run, so the baseline written here is the one PR ratchet
+# checks compare against.
+
+'on':
+  push:
+    branches: [main]
+
+jobs:
+  coverage-upload:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    env:
+      CARGO_TERM_COLOR: always
+      BUILD_PROFILE: debug
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+      - name: Setup Rust
+        uses: leynos/shared-actions/.github/actions/setup-rust@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
+      - name: Test and Measure Coverage
+        uses: leynos/shared-actions/.github/actions/generate-coverage@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
+        with:
+          features: internal
+          output-path: lcov.info
+          format: lcov
+          with-ratchet: 'true'
+      - name: Upload coverage data to CodeScene
+        env:
+          CS_ACCESS_TOKEN: ${{ secrets.CS_ACCESS_TOKEN }}
+        if: ${{ env.CS_ACCESS_TOKEN }}
+        uses: leynos/shared-actions/.github/actions/upload-codescene-coverage@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
+        with:
+          format: lcov
+          access-token: ${{ env.CS_ACCESS_TOKEN }}
+          installer-checksum: ${{ vars.CODESCENE_CLI_SHA256 }}

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -28,6 +28,6 @@ jobs:
       # The token is not used for any external cloud auth.
       id-token: write
     if: ${{ github.event_name == 'workflow_dispatch' || github.actor == 'dependabot[bot]' }}
-    uses: leynos/shared-actions/.github/workflows/dependabot-automerge.yml@2b09d10192627fd6e1034e7c12625dd266b45503
+    uses: leynos/shared-actions/.github/workflows/dependabot-automerge.yml@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
     with:
       pull-request-number: ${{ inputs.pull-request-number || github.event.pull_request.number }}


### PR DESCRIPTION
## Summary

- Bump the `leynos/shared-actions` pin repo-wide (ci.yml, audit.yml,
  dependabot-automerge.yml) to `927edd45ae77be4251a8a18ca9eb5613a2e32cbd`,
  the SHA that introduces the coverage actions' `mode: check` support
  and fixes the `upload-codescene-coverage` and `generate-coverage`
  defects described in shared-actions#333.
- Move CodeScene coverage upload out of the pull-request job and into
  a new [`coverage-main.yml`](https://github.com/leynos/podbot/blob/codescene-coverage-gate/.github/workflows/coverage-main.yml),
  triggered on push to `main`. The previous PR-job upload step
  defaulted to `mode: upload`, which CodeScene rejects for branches it
  does not analyse (only `main`); once `CS_ACCESS_TOKEN` was set it
  would have started failing every pull-request run.
- Enable the coverage ratchet (`with-ratchet: 'true'`) in both the PR
  coverage-generation step in
  [`ci.yml`](https://github.com/leynos/podbot/blob/codescene-coverage-gate/.github/workflows/ci.yml)
  and the new main-branch upload job, and add `fetch-depth: 0` to the
  PR checkout so a future `mode: check` step can resolve the merge
  base.
- Leave a comment in `ci.yml` explaining that the `mode: check`
  changed-line gate is deferred: CodeScene project 75835 has no
  coverage-gates configuration yet, matching the estate-wide finding
  from ddlint#287 and chutoro#156. Enabling it is a CodeScene-side
  per-project toggle, not a CI change.

## Review walkthrough

- [`ci.yml`](https://github.com/leynos/podbot/blob/codescene-coverage-gate/.github/workflows/ci.yml):
  pin bump, `fetch-depth: 0` on checkout, `with-ratchet: 'true'` on
  the coverage-generation step, removal of the PR-job upload step
  (replaced by a comment explaining the deferral and the move to
  `coverage-main.yml`).
- [`coverage-main.yml`](https://github.com/leynos/podbot/blob/codescene-coverage-gate/.github/workflows/coverage-main.yml)
  (new): push-to-main job that regenerates coverage with the ratchet
  enabled and uploads it to CodeScene with the default `mode: upload`,
  guarded so it no-ops while `CS_ACCESS_TOKEN` is unset.
- [`audit.yml`](https://github.com/leynos/podbot/blob/codescene-coverage-gate/.github/workflows/audit.yml)
  and
  [`dependabot-automerge.yml`](https://github.com/leynos/podbot/blob/codescene-coverage-gate/.github/workflows/dependabot-automerge.yml):
  pin bump only, no behavioural change.

Note for reviewers: the `CodeScene Code Coverage` check is not a
required check in this repo's ruleset (`build-test` is the only
required check) — it posts as an informational status via the
CodeScene GitHub App and affects the PR status rollup, not branch
protection directly.

## Validation

- `python3 -c "import yaml; [yaml.safe_load(open(f)) for f in
  ('.github/workflows/ci.yml', '.github/workflows/coverage-main.yml',
  '.github/workflows/audit.yml',
  '.github/workflows/dependabot-automerge.yml')]"` — all four parse
  cleanly.
- No workflow-contract tests reference the shared-actions pin in this
  repo (`tests/` has no such coverage), so none needed updating.
- Confirmed the existing coverage-generation step runs in ~4 minutes
  (well under the new pin's 600 s cargo wall-clock cap) and the
  workspace is a single small crate, so neither the
  `RUN_RUST_CARGO_WAIT_TIMEOUT` override nor the disk-exhaustion
  workaround from the estate rollout apply here.
- `CS_ACCESS_TOKEN` will be set in both the Actions and Dependabot
  secret stores immediately after this PR merges, not before: several
  other open PRs on this repo still carry the old `ci.yml`, whose
  PR-job upload step defaults to `mode: upload` (rejected by CodeScene
  for non-main branches). Setting the secret before this merges would
  break coverage on every one of those stale PR heads. This PR removes
  that step from `ci.yml`, so once it lands on `main`, setting the
  secret is safe and lets the new `coverage-main.yml` job upload on
  the next push to main.
