### PR TITLE
Allow manual dispatch of the main-branch coverage upload

### DIFF
--- a/.github/workflows/coverage-main.yml
+++ b/.github/workflows/coverage-main.yml
@@ -12,6 +12,7 @@ name: Coverage (main)
 'on':
   push:
     branches: [main]
+  workflow_dispatch:
 
 jobs:
   coverage-upload:


### PR DESCRIPTION
## Summary

- Add `workflow_dispatch` to `coverage-main.yml` so the CodeScene upload can be re-run on demand.

## Review walkthrough

- [`coverage-main.yml`](https://github.com/leynos/podbot/blob/coverage-main-dispatch-trigger/.github/workflows/coverage-main.yml): one-line trigger addition, no behavioural change to the existing push-to-main path.

## Validation

- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/coverage-main.yml'))"` — parses cleanly.
- Context: the first push-to-main run of this workflow (immediately after #135 merged) skipped the CodeScene upload step because `CS_ACCESS_TOKEN` was set a few seconds after the run had already been dispatched — a job's secret context is fixed at dispatch, not re-read mid-run. This trigger lets us verify the upload succeeds without waiting for the next incidental push to main.