### PR TITLE
Restore green CI: whitaker-installer 0.2.7 and generate-coverage ratchet fix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     env:
       CARGO_TERM_COLOR: always
       BUILD_PROFILE: debug
-      WHITAKER_INSTALLER_VERSION: '0.2.5'
+      WHITAKER_INSTALLER_VERSION: '0.2.6'
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     env:
       CARGO_TERM_COLOR: always
       BUILD_PROFILE: debug
-      WHITAKER_INSTALLER_VERSION: '0.2.6'
+      WHITAKER_INSTALLER_VERSION: '0.2.7'
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,7 +77,7 @@ jobs:
       - name: Internal compatibility tests
         run: cargo test --features internal
       - name: Test and Measure Coverage
-        uses: leynos/shared-actions/.github/actions/generate-coverage@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
+        uses: leynos/shared-actions/.github/actions/generate-coverage@1c1a46f0b4fde6dd78a9757fc475a5d06ee891c7
         with:
           features: internal
           output-path: lcov.info
@@ -88,7 +88,7 @@ jobs:
         env:
           CS_ACCESS_TOKEN: ${{ secrets.CS_ACCESS_TOKEN }}
         if: github.event_name == 'pull_request' && env.CS_ACCESS_TOKEN != ''
-        uses: leynos/shared-actions/.github/actions/upload-codescene-coverage@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
+        uses: leynos/shared-actions/.github/actions/upload-codescene-coverage@1c1a46f0b4fde6dd78a9757fc475a5d06ee891c7
         with:
           format: lcov
           mode: check

--- a/.github/workflows/coverage-main.yml
+++ b/.github/workflows/coverage-main.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Setup Rust
         uses: leynos/shared-actions/.github/actions/setup-rust@dfddcb6cf53a2583e55bf0c3536c01ed1f67dc16
       - name: Test and Measure Coverage
-        uses: leynos/shared-actions/.github/actions/generate-coverage@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
+        uses: leynos/shared-actions/.github/actions/generate-coverage@1c1a46f0b4fde6dd78a9757fc475a5d06ee891c7
         with:
           features: internal
           output-path: lcov.info


### PR DESCRIPTION
## Summary

This branch restores green CI for podbot, which was failing on two independent, unrelated causes. It applies the minimal fix for each.

### 1. Whitaker installer (`0.2.6` → `0.2.7`)

Installer 0.2.6 downloaded the correct, checksummed `dylint-link` 6.0.1 artefact but then executed it as a `--help` health check. `dylint-link` is a linker wrapper with no reliable self-reporting subcommand, so the probe failed and verification fell back to a source build. Installer 0.2.7 ([leynos/whitaker#299](https://github.com/leynos/whitaker/issues/299)) trusts the verified repository artefact instead; the suite now installs from the release directly (confirmed in this branch's run: "Installed dylint-link from repository release").

### 2. Coverage ratchet (`generate-coverage` pin `927edd45` → `1c1a46f0`)

Separately, the `lint-test` job's coverage ratchet false-tripped on a 0.07 percentage-point dip below a stale cached baseline (86.39% vs 86.46%), and that failure surfaced as a confusing "empty artifact name" upload error that masked it. Bumping the `generate-coverage` and `upload-codescene-coverage` pins brings the ±1pp ratchet tolerance dead-band ([leynos/shared-actions#353](https://github.com/leynos/shared-actions/pull/353)), which absorbs measurement jitter, and the archive-masking fix ([leynos/shared-actions#380](https://github.com/leynos/shared-actions/pull/380)), which surfaces a genuine ratchet failure instead of an empty-name error.

## Changes

- Set `WHITAKER_INSTALLER_VERSION` from `0.2.6` to `0.2.7` in [.github/workflows/ci.yml](https://github.com/leynos/podbot/blob/bump-whitaker-installer-0.2.6/.github/workflows/ci.yml).
- Bump the `generate-coverage` and `upload-codescene-coverage` pins from `927edd45` to `1c1a46f0` in `ci.yml` and `coverage-main.yml`. The `setup-rust` pin is unchanged.

## Validation

- CI on this PR exercises both paths: the Whitaker install now provisions `dylint-link` from the repository release, and the coverage ratchet passes within the dead-band.

## Notes

No Rust toolchain pin is changed and the Whitaker lint gate is not weakened.
