### PR TITLE
Bump remaining shared-actions pins to 1c1a46f0

### DIFF
--- a/.github/workflows/coverage-main.yml
+++ b/.github/workflows/coverage-main.yml
@@ -38,7 +38,7 @@ jobs:
         env:
           CS_ACCESS_TOKEN: ${{ secrets.CS_ACCESS_TOKEN }}
         if: ${{ env.CS_ACCESS_TOKEN }}
-        uses: leynos/shared-actions/.github/actions/upload-codescene-coverage@d3cbe87e745e07b3ad53ddcb87deb19ffa95c9b8
+        uses: leynos/shared-actions/.github/actions/upload-codescene-coverage@1c1a46f0b4fde6dd78a9757fc475a5d06ee891c7
         with:
           format: lcov
           access-token: ${{ env.CS_ACCESS_TOKEN }}

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -28,6 +28,6 @@ jobs:
       # The token is not used for any external cloud auth.
       id-token: write
     if: ${{ github.event_name == 'workflow_dispatch' || github.actor == 'dependabot[bot]' }}
-    uses: leynos/shared-actions/.github/workflows/dependabot-automerge.yml@d3cbe87e745e07b3ad53ddcb87deb19ffa95c9b8
+    uses: leynos/shared-actions/.github/workflows/dependabot-automerge.yml@1c1a46f0b4fde6dd78a9757fc475a5d06ee891c7
     with:
       pull-request-number: ${{ inputs.pull-request-number || github.event.pull_request.number }}


### PR DESCRIPTION
## Summary
Rebased onto `main`, which meanwhile picked up most of this bump directly
via #147. Only two `leynos/shared-actions` references had not caught up:
the `dependabot-automerge` reusable workflow and `coverage-main`'s
`upload-codescene-coverage` action, both still pinned to the older
`d3cbe87e` commit. This PR now brings just those two references to
`1c1a46f0b4fde6dd78a9757fc475a5d06ee891c7`, matching every other
`leynos/shared-actions` reference already on `main`.

## Review walkthrough
Two-line SHA substitution, one in each of `coverage-main.yml` and
`dependabot-automerge.yml`. No other references changed, since `main`
already carries them.

## Validation
CI on this pull request exercises the bumped references directly.
