### PR TITLE
Bump whitaker-installer to 0.2.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     env:
       CARGO_TERM_COLOR: always
       BUILD_PROFILE: debug
-      WHITAKER_INSTALLER_VERSION: '0.2.5'
+      WHITAKER_INSTALLER_VERSION: '0.2.6'
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:


### PR DESCRIPTION
## Summary
Bumps `WHITAKER_INSTALLER_VERSION` from 0.2.5 to 0.2.6 in ci.yml.

## Review walkthrough
One-line env change. The 0.2.5 installer builds dylint_driver 4.1.0, which fails to compile on the current nightly (E0609 `env_depinfo`), breaking the lint step on every run — the same pre-existing drift already fixed in monotony, chutoro, and tei-rapporteur.

## Validation
CI on this pull request exercises the lint step with the new installer.