### PR TITLE
Allow no_expect_outside_tests pending whitaker#311

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,11 @@ target/%/$(TARGET): ## Build binary in debug or release mode
 lint: ## Run Clippy and the Whitaker Dylint suite with warnings denied
 	RUSTDOCFLAGS="$(RUSTDOC_FLAGS)" $(CARGO) doc --no-deps
 	$(CARGO) clippy $(CLIPPY_FLAGS)
-	RUSTFLAGS="$(RUST_FLAGS)" $(WHITAKER) --all -- $(CARGO_FLAGS)
+# TODO: drop -A no_expect_outside_tests once leynos/whitaker#311 is fixed:
+# rolling suite build 4e8a8ab regressed the #[cfg(test)] companion-module
+# exemption and flags expect() calls in test-only helper functions under
+# src/**/tests/.
+	RUSTFLAGS="$(RUST_FLAGS) -A no_expect_outside_tests" $(WHITAKER) --all -- $(CARGO_FLAGS)
 
 typecheck: ## Type-check the workspace
 	RUSTFLAGS="$(RUST_FLAGS)" $(CARGO) check $(CARGO_FLAGS) $(BUILD_JOBS)


### PR DESCRIPTION
## Summary
Temporarily allows the `no_expect_outside_tests` Whitaker lint in the lint
gate, pending leynos/whitaker#311.

Rolling suite build `4e8a8ab` (from leynos/whitaker commit `4e8a8ab6`,
PR leynos/whitaker#238) regressed the `#[cfg(test)]` companion-module
exemption: `expect()` calls inside helper and fixture functions under
`src/**/tests/` are now flagged as "outside test-only code" even though the
enclosing module is declared `#[cfg(test)]`. Suite build `2bc0c3f` (v0.2.7)
linted the same code clean, and the rolling release no longer serves older
artefacts, so every CI run fails the lint gate with 22 false positives
(see run 30115224258).

## Review walkthrough
One-line change to the `lint` target in the Makefile, appending
`-A no_expect_outside_tests` to `RUSTFLAGS` for the Whitaker invocation
only. Clippy and the rest of the suite keep denying warnings. A TODO
records the revert condition (leynos/whitaker#311).

## Validation
CI on this pull request exercises the lint gate with the allowance in
place.
